### PR TITLE
Add 'Additional Files' option to GUI

### DIFF
--- a/source/component/PasDoc_Base.pas
+++ b/source/component/PasDoc_Base.pas
@@ -244,6 +244,7 @@ begin
   FDirectives := NewStringVector;
   FIncludeDirectories := NewStringVector;
   FSourceFileNames := NewStringVector;
+  FAdditionalFilesNames := TStringList.Create();
 
   { Set default property values }
   FGeneratorInfo := true;
@@ -265,6 +266,7 @@ begin
   FDirectives.Free;
   FIncludeDirectories.Free;
   FSourceFileNames.Free;
+  FAdditionalFilesNames.Free;
   FUnits.Free;
   FConclusion.Free;
   FIntroduction.Free;

--- a/source/gui/frmhelpgeneratorunit.lfm
+++ b/source/gui/frmhelpgeneratorunit.lfm
@@ -1,7 +1,7 @@
 object frmHelpGenerator: TfrmHelpGenerator
-  Left = 471
+  Left = 259
   Height = 608
-  Top = 141
+  Top = 44
   Width = 1068
   HelpType = htKeyword
   HelpKeyword = 'PasDocGui'
@@ -10,9 +10,8 @@ object frmHelpGenerator: TfrmHelpGenerator
   ActiveControl = PanelLeft
   AutoSize = True
   Caption = 'pasdoc gui'
-  ClientHeight = 573
+  ClientHeight = 588
   ClientWidth = 1068
-  DesignTimePPI = 140
   KeyPreview = True
   Menu = MainMenu1
   OnClose = FormClose
@@ -21,10 +20,10 @@ object frmHelpGenerator: TfrmHelpGenerator
   OnKeyDown = FormKeyDown
   Position = poScreenCenter
   ShowHint = True
-  LCLVersion = '1.8.0.6'
+  LCLVersion = '1.8.4.0'
   object NotebookMain: TNotebook
     Left = 208
-    Height = 573
+    Height = 588
     Top = 0
     Width = 860
     PageIndex = 5
@@ -35,9 +34,9 @@ object frmHelpGenerator: TfrmHelpGenerator
       Hint = 'Options'
       object LabelTitle: TLabel
         Left = 8
-        Height = 27
+        Height = 15
         Top = 8
-        Width = 39
+        Width = 23
         HelpType = htKeyword
         Caption = 'Title'
         FocusControl = edTitle
@@ -47,9 +46,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = edTitle
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 72
-        Width = 114
+        Height = 15
+        Top = 46
+        Width = 66
         HelpType = htKeyword
         Caption = 'Output Type'
         FocusControl = comboGenerateFormat
@@ -59,9 +58,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditOutputDirectory
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 200
-        Width = 455
+        Height = 15
+        Top = 122
+        Width = 267
         HelpType = htKeyword
         Caption = 'Output filename (without directory; not for HTML)'
         FocusControl = edProjectName
@@ -71,9 +70,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = edProjectName
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 264
-        Width = 91
+        Height = 15
+        Top = 160
+        Width = 52
         HelpType = htKeyword
         Caption = 'Language'
         FocusControl = comboLanguages
@@ -83,9 +82,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = comboGenerateFormat
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 136
-        Width = 152
+        Height = 15
+        Top = 84
+        Width = 88
         HelpType = htKeyword
         Caption = 'Output directory'
         ParentColor = False
@@ -94,10 +93,10 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = CheckUseTipueSearch
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 31
+        Height = 19
         Hint = 'If this is checked, the 1st sentence of each description'#10'will be treated as the abstract of that description'#10'(unless you override it by using the @abstract tag).'
-        Top = 394
-        Width = 758
+        Top = 236
+        Width = 447
         HelpType = htKeyword
         HelpKeyword = 'AutoAbstractOption'
         Caption = 'Automatically deduce @abstract description from the 1st sentence of description'
@@ -108,10 +107,10 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = CheckWriteUsesList
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 31
+        Height = 19
         Hint = 'Check this to get working "Search" button in your HTML documentation.'
-        Top = 363
-        Width = 390
+        Top = 217
+        Width = 233
         HelpType = htKeyword
         HelpKeyword = 'UseTipueSearchOption'
         Caption = 'Use tipue search engine in HTML output'
@@ -122,9 +121,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelTitle
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
+        Height = 23
         Hint = 'Title for your documentation. In HTML output, this appears in the web browser caption.'
-        Top = 35
+        Top = 23
         Width = 274
         HelpType = htKeyword
         HelpKeyword = 'DocumentationTitle'
@@ -135,11 +134,11 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelOutputType
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
-        Top = 99
+        Height = 23
+        Top = 61
         Width = 254
         HelpType = htKeyword
-        ItemHeight = 0
+        ItemHeight = 15
         Items.Strings = (
           'HTML'
           'HTML Help Workshop'
@@ -154,9 +153,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelProjectName
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
+        Height = 23
         Hint = 'The project name is used to specify the main part of '#10'the output file name for HtmlHelp or LaTeX output.'
-        Top = 227
+        Top = 137
         Width = 274
         HelpType = htKeyword
         HelpKeyword = 'NameOption'
@@ -167,13 +166,13 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelLanguages
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 41
-        Top = 291
+        Height = 23
+        Top = 175
         Width = 533
         HelpType = htKeyword
         HelpKeyword = 'OutputLanguage'
         Anchors = [akTop, akLeft, akRight]
-        ItemHeight = 0
+        ItemHeight = 15
         OnChange = comboLanguagesChange
         Style = csDropDownList
         TabOrder = 5
@@ -182,9 +181,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = CheckAutoAbstract
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 31
-        Top = 425
-        Width = 421
+        Height = 19
+        Top = 255
+        Width = 250
         HelpType = htKeyword
         HelpKeyword = 'NoMacroOption'
         Caption = 'Recognize FPC macros syntax when parsing'
@@ -197,9 +196,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = CheckHandleMacros
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 31
-        Top = 456
-        Width = 370
+        Height = 19
+        Top = 274
+        Width = 218
         HelpType = htKeyword
         HelpKeyword = 'PasDocGui/StoreRelativePaths'
         Caption = 'Store only relative paths in project file'
@@ -212,9 +211,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = comboLanguages
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 31
-        Top = 332
-        Width = 201
+        Height = 19
+        Top = 198
+        Width = 122
         HelpType = htKeyword
         HelpKeyword = 'WriteUsesList'
         Caption = 'Show units uses list'
@@ -225,8 +224,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelOutputDirectory
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
-        Top = 163
+        Height = 23
+        Top = 99
         Width = 483
         HelpType = htKeyword
         HelpKeyword = 'OutputOption'
@@ -243,7 +242,7 @@ object frmHelpGenerator: TfrmHelpGenerator
       Hint = 'Source Files'
       object Label8: TLabel
         Left = 8
-        Height = 81
+        Height = 30
         Top = 8
         Width = 822
         HelpType = htKeyword
@@ -258,8 +257,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = btnBrowseSourceFiles
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 418
-        Top = 146
+        Height = 483
+        Top = 81
         Width = 840
         HelpType = htKeyword
         Anchors = [akTop, akLeft, akRight, akBottom]
@@ -273,8 +272,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = Label8
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 47
-        Top = 89
+        Height = 33
+        Top = 38
         Width = 840
         Align = alCustom
         Anchors = [akTop, akLeft, akRight]
@@ -289,20 +288,20 @@ object frmHelpGenerator: TfrmHelpGenerator
       Hint = 'Include Directories'
       object PanelIncludeDirectoriesTop: TPanel
         Left = 0
-        Height = 121
+        Height = 83
         Top = 0
         Width = 860
         Align = alTop
         AutoSize = True
         BevelOuter = bvNone
         BorderWidth = 10
-        ClientHeight = 121
+        ClientHeight = 83
         ClientWidth = 860
         FullRepaint = False
         TabOrder = 1
         object Label9: TLabel
           Left = 10
-          Height = 54
+          Height = 30
           Top = 10
           Width = 840
           HelpType = htKeyword
@@ -314,8 +313,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         end
         object btnBrowseIncludeDirectory: TButton
           Left = 10
-          Height = 47
-          Top = 64
+          Height = 33
+          Top = 40
           Width = 840
           Align = alTop
           AutoSize = True
@@ -327,8 +326,8 @@ object frmHelpGenerator: TfrmHelpGenerator
       end
       object memoIncludeDirectories: TMemo
         Left = 10
-        Height = 432
-        Top = 131
+        Height = 485
+        Top = 93
         Width = 840
         HelpType = htKeyword
         HelpKeyword = 'IncludeInSearchPath'
@@ -450,9 +449,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditIntroductionFileName
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 146
-        Width = 133
+        Height = 15
+        Top = 94
+        Width = 79
         HelpType = htKeyword
         Caption = 'Conclusion file'
         FocusControl = EditConclusionFileName
@@ -462,9 +461,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditCssFileName
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 82
-        Width = 148
+        Height = 15
+        Top = 56
+        Width = 85
         HelpType = htKeyword
         BorderSpacing.Top = 10
         Caption = 'Introduction file'
@@ -474,10 +473,10 @@ object frmHelpGenerator: TfrmHelpGenerator
       object LabelCssFileName: TLabel
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
+        Height = 15
         Hint = 'Custom CSS file. Leave empty to use default pasdoc.css.'
         Top = 8
-        Width = 311
+        Width = 185
         HelpType = htKeyword
         Caption = 'Custom CSS file (for HTML output)'
         FocusControl = EditCssFileName
@@ -487,9 +486,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelConclusionFile
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
+        Height = 23
         Hint = 'Optional file used as a conclusion to your project.'
-        Top = 173
+        Top = 109
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'IntroductionAndConclusion'
@@ -508,9 +507,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelIntroductionFile
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
+        Height = 23
         Hint = 'Optional file used as an introduction to your project.'
-        Top = 109
+        Top = 71
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'IntroductionAndConclusion'
@@ -529,8 +528,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelCssFileName
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
-        Top = 35
+        Height = 23
+        Top = 23
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'CssOption'
@@ -550,9 +549,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditConclusionFileName
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 220
-        Width = 299
+        Height = 15
+        Top = 142
+        Width = 180
         HelpType = htKeyword
         BorderSpacing.Top = 10
         Caption = 'Additional HTML <head> content'
@@ -563,8 +562,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelHtmlHead
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
-        Top = 247
+        Height = 23
+        Top = 157
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'HtmlHeadBodyBeginEndOptions'
@@ -583,9 +582,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditHtmlHead
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 284
-        Width = 397
+        Height = 15
+        Top = 180
+        Width = 236
         HelpType = htKeyword
         Caption = 'Additional HTML content right after <body>'
         FocusControl = EditHtmlBodyBegin
@@ -595,8 +594,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelHtmlBodyBegin
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
-        Top = 311
+        Height = 23
+        Top = 195
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'HtmlHeadBodyBeginEndOptions'
@@ -615,9 +614,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditHtmlBodyBegin
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
-        Top = 348
-        Width = 421
+        Height = 15
+        Top = 218
+        Width = 251
         HelpType = htKeyword
         Caption = 'Additional HTML content right  before</body>'
         FocusControl = EditHtmlBodyEnd
@@ -627,8 +626,8 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelHtmlBodyEnd
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
-        Top = 375
+        Height = 23
+        Top = 233
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'HtmlHeadBodyBeginEndOptions'
@@ -647,10 +646,10 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = EditHtmlBodyEnd
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 27
+        Height = 15
         Hint = 'Additional descriptions, added to the of comments present in Pascal source files.'
-        Top = 422
-        Width = 191
+        Top = 266
+        Width = 108
         HelpType = htKeyword
         BorderSpacing.Top = 10
         Caption = 'External descriptions'
@@ -661,9 +660,9 @@ object frmHelpGenerator: TfrmHelpGenerator
         AnchorSideTop.Control = LabelExternalDescriptions
         AnchorSideTop.Side = asrBottom
         Left = 8
-        Height = 37
+        Height = 23
         Hint = 'Optional file with external descriptions'
-        Top = 449
+        Top = 281
         Width = 717
         HelpType = htKeyword
         HelpKeyword = 'ReadDescriptionFromFile'
@@ -677,6 +676,48 @@ object frmHelpGenerator: TfrmHelpGenerator
         MaxLength = 0
         TabOrder = 6
         OnChange = SomethingChanged
+      end
+      object MemoAdditionalFiles: TMemo
+        AnchorSideTop.Control = LabelAdditionalFiles
+        AnchorSideTop.Side = asrBottom
+        Left = 8
+        Height = 235
+        Hint = 'Path to additional files to be added to the documentation '
+        Top = 329
+        Width = 688
+        HelpType = htKeyword
+        Anchors = [akTop, akLeft, akRight, akBottom]
+        OnChange = SomethingChanged
+        ScrollBars = ssAutoBoth
+        TabOrder = 7
+        WordWrap = False
+      end
+      object LabelAdditionalFiles: TLabel
+        AnchorSideTop.Control = EditExternalDescriptions
+        AnchorSideTop.Side = asrBottom
+        Left = 8
+        Height = 15
+        Top = 314
+        Width = 79
+        BorderSpacing.Top = 10
+        Caption = 'Additional files'
+        FocusControl = MemoAdditionalFiles
+        ParentColor = False
+      end
+      object BtnBrowseAdditionalFiles: TButton
+        AnchorSideTop.Control = Label8
+        AnchorSideTop.Side = asrBottom
+        Left = 702
+        Height = 33
+        Top = 329
+        Width = 56
+        Align = alCustom
+        Anchors = [akTop, akLeft, akRight]
+        AutoSize = True
+        BorderSpacing.InnerBorder = 4
+        Caption = 'Browse'
+        OnClick = BtnBrowseAdditionalFilesClick
+        TabOrder = 8
       end
     end
     object pageLatexOptions: TPage
@@ -1211,346 +1252,346 @@ object frmHelpGenerator: TfrmHelpGenerator
         ParentFont = False
         TabOrder = 1
         Gutter.Width = 57
-        Gutter.MouseActions = <        
+        Gutter.MouseActions = <
           item
             ClickCount = ccAny
             ClickDir = cdDown
             Command = emcOnMainGutterClick
-          end        
+          end
           item
             Button = mbRight
             Command = emcContextMenu
           end>
         RightGutter.Width = 0
         RightGutter.MouseActions = <>
-        Keystrokes = <        
+        Keystrokes = <
           item
             Command = ecUp
             ShortCut = 38
-          end        
+          end
           item
             Command = ecSelUp
             ShortCut = 8230
-          end        
+          end
           item
             Command = ecScrollUp
             ShortCut = 16422
-          end        
+          end
           item
             Command = ecDown
             ShortCut = 40
-          end        
+          end
           item
             Command = ecSelDown
             ShortCut = 8232
-          end        
+          end
           item
             Command = ecScrollDown
             ShortCut = 16424
-          end        
+          end
           item
             Command = ecLeft
             ShortCut = 37
-          end        
+          end
           item
             Command = ecSelLeft
             ShortCut = 8229
-          end        
+          end
           item
             Command = ecWordLeft
             ShortCut = 16421
-          end        
+          end
           item
             Command = ecSelWordLeft
             ShortCut = 24613
-          end        
+          end
           item
             Command = ecRight
             ShortCut = 39
-          end        
+          end
           item
             Command = ecSelRight
             ShortCut = 8231
-          end        
+          end
           item
             Command = ecWordRight
             ShortCut = 16423
-          end        
+          end
           item
             Command = ecSelWordRight
             ShortCut = 24615
-          end        
+          end
           item
             Command = ecPageDown
             ShortCut = 34
-          end        
+          end
           item
             Command = ecSelPageDown
             ShortCut = 8226
-          end        
+          end
           item
             Command = ecPageBottom
             ShortCut = 16418
-          end        
+          end
           item
             Command = ecSelPageBottom
             ShortCut = 24610
-          end        
+          end
           item
             Command = ecPageUp
             ShortCut = 33
-          end        
+          end
           item
             Command = ecSelPageUp
             ShortCut = 8225
-          end        
+          end
           item
             Command = ecPageTop
             ShortCut = 16417
-          end        
+          end
           item
             Command = ecSelPageTop
             ShortCut = 24609
-          end        
+          end
           item
             Command = ecLineStart
             ShortCut = 36
-          end        
+          end
           item
             Command = ecSelLineStart
             ShortCut = 8228
-          end        
+          end
           item
             Command = ecEditorTop
             ShortCut = 16420
-          end        
+          end
           item
             Command = ecSelEditorTop
             ShortCut = 24612
-          end        
+          end
           item
             Command = ecLineEnd
             ShortCut = 35
-          end        
+          end
           item
             Command = ecSelLineEnd
             ShortCut = 8227
-          end        
+          end
           item
             Command = ecEditorBottom
             ShortCut = 16419
-          end        
+          end
           item
             Command = ecSelEditorBottom
             ShortCut = 24611
-          end        
+          end
           item
             Command = ecToggleMode
             ShortCut = 45
-          end        
+          end
           item
             Command = ecCopy
             ShortCut = 16429
-          end        
+          end
           item
             Command = ecPaste
             ShortCut = 8237
-          end        
+          end
           item
             Command = ecDeleteChar
             ShortCut = 46
-          end        
+          end
           item
             Command = ecCut
             ShortCut = 8238
-          end        
+          end
           item
             Command = ecDeleteLastChar
             ShortCut = 8
-          end        
+          end
           item
             Command = ecDeleteLastChar
             ShortCut = 8200
-          end        
+          end
           item
             Command = ecDeleteLastWord
             ShortCut = 16392
-          end        
+          end
           item
             Command = ecUndo
             ShortCut = 32776
-          end        
+          end
           item
             Command = ecRedo
             ShortCut = 40968
-          end        
+          end
           item
             Command = ecLineBreak
             ShortCut = 13
-          end        
+          end
           item
             Command = ecSelectAll
             ShortCut = 16449
-          end        
+          end
           item
             Command = ecCopy
             ShortCut = 16451
-          end        
+          end
           item
             Command = ecBlockIndent
             ShortCut = 24649
-          end        
+          end
           item
             Command = ecLineBreak
             ShortCut = 16461
-          end        
+          end
           item
             Command = ecInsertLine
             ShortCut = 16462
-          end        
+          end
           item
             Command = ecDeleteWord
             ShortCut = 16468
-          end        
+          end
           item
             Command = ecBlockUnindent
             ShortCut = 24661
-          end        
+          end
           item
             Command = ecPaste
             ShortCut = 16470
-          end        
+          end
           item
             Command = ecCut
             ShortCut = 16472
-          end        
+          end
           item
             Command = ecDeleteLine
             ShortCut = 16473
-          end        
+          end
           item
             Command = ecDeleteEOL
             ShortCut = 24665
-          end        
+          end
           item
             Command = ecUndo
             ShortCut = 16474
-          end        
+          end
           item
             Command = ecRedo
             ShortCut = 24666
-          end        
+          end
           item
             Command = ecGotoMarker0
             ShortCut = 16432
-          end        
+          end
           item
             Command = ecGotoMarker1
             ShortCut = 16433
-          end        
+          end
           item
             Command = ecGotoMarker2
             ShortCut = 16434
-          end        
+          end
           item
             Command = ecGotoMarker3
             ShortCut = 16435
-          end        
+          end
           item
             Command = ecGotoMarker4
             ShortCut = 16436
-          end        
+          end
           item
             Command = ecGotoMarker5
             ShortCut = 16437
-          end        
+          end
           item
             Command = ecGotoMarker6
             ShortCut = 16438
-          end        
+          end
           item
             Command = ecGotoMarker7
             ShortCut = 16439
-          end        
+          end
           item
             Command = ecGotoMarker8
             ShortCut = 16440
-          end        
+          end
           item
             Command = ecGotoMarker9
             ShortCut = 16441
-          end        
+          end
           item
             Command = ecSetMarker0
             ShortCut = 24624
-          end        
+          end
           item
             Command = ecSetMarker1
             ShortCut = 24625
-          end        
+          end
           item
             Command = ecSetMarker2
             ShortCut = 24626
-          end        
+          end
           item
             Command = ecSetMarker3
             ShortCut = 24627
-          end        
+          end
           item
             Command = ecSetMarker4
             ShortCut = 24628
-          end        
+          end
           item
             Command = ecSetMarker5
             ShortCut = 24629
-          end        
+          end
           item
             Command = ecSetMarker6
             ShortCut = 24630
-          end        
+          end
           item
             Command = ecSetMarker7
             ShortCut = 24631
-          end        
+          end
           item
             Command = ecSetMarker8
             ShortCut = 24632
-          end        
+          end
           item
             Command = ecSetMarker9
             ShortCut = 24633
-          end        
+          end
           item
             Command = ecNormalSelect
             ShortCut = 24654
-          end        
+          end
           item
             Command = ecColumnSelect
             ShortCut = 24643
-          end        
+          end
           item
             Command = ecLineSelect
             ShortCut = 24652
-          end        
+          end
           item
             Command = ecTab
             ShortCut = 9
-          end        
+          end
           item
             Command = ecShiftTab
             ShortCut = 8201
-          end        
+          end
           item
             Command = ecMatchBracket
             ShortCut = 24642
           end>
-        MouseActions = <        
+        MouseActions = <
           item
             ShiftMask = [ssShift, ssAlt]
             ClickDir = cdDown
             Command = emcStartSelections
             MoveCaret = True
-          end        
+          end
           item
             Shift = [ssShift]
             ShiftMask = [ssShift, ssAlt]
@@ -1558,14 +1599,14 @@ object frmHelpGenerator: TfrmHelpGenerator
             Command = emcStartSelections
             MoveCaret = True
             Option = 1
-          end        
+          end
           item
             Shift = [ssAlt]
             ShiftMask = [ssShift, ssAlt]
             ClickDir = cdDown
             Command = emcStartColumnSelections
             MoveCaret = True
-          end        
+          end
           item
             Shift = [ssShift, ssAlt]
             ShiftMask = [ssShift, ssAlt]
@@ -1573,42 +1614,42 @@ object frmHelpGenerator: TfrmHelpGenerator
             Command = emcStartColumnSelections
             MoveCaret = True
             Option = 1
-          end        
+          end
           item
             Button = mbRight
             Command = emcContextMenu
-          end        
+          end
           item
             ClickCount = ccDouble
             ClickDir = cdDown
             Command = emcSelectWord
             MoveCaret = True
-          end        
+          end
           item
             ClickCount = ccTriple
             ClickDir = cdDown
             Command = emcSelectLine
             MoveCaret = True
-          end        
+          end
           item
             ClickCount = ccQuad
             ClickDir = cdDown
             Command = emcSelectPara
             MoveCaret = True
-          end        
+          end
           item
             Button = mbMiddle
             ClickDir = cdDown
             Command = emcPasteSelection
             MoveCaret = True
-          end        
+          end
           item
             Shift = [ssCtrl]
             ShiftMask = [ssShift, ssAlt, ssCtrl]
             Command = emcMouseLink
           end>
         MouseTextActions = <>
-        MouseSelActions = <        
+        MouseSelActions = <
           item
             ClickDir = cdDown
             Command = emcStartDragMove
@@ -1660,18 +1701,18 @@ object frmHelpGenerator: TfrmHelpGenerator
             MarkupInfo.Foreground = clGray
           end
           object TSynGutterCodeFolding
-            MouseActions = <            
+            MouseActions = <
               item
                 Button = mbRight
                 Command = emcCodeFoldContextMenu
-              end            
+              end
               item
                 ShiftMask = [ssShift]
                 Button = mbMiddle
                 ClickCount = ccAny
                 ClickDir = cdDown
                 Command = emcCodeFoldCollaps
-              end            
+              end
               item
                 Shift = [ssShift]
                 ShiftMask = [ssShift]
@@ -1680,7 +1721,7 @@ object frmHelpGenerator: TfrmHelpGenerator
                 ClickDir = cdDown
                 Command = emcCodeFoldCollaps
                 Option = 1
-              end            
+              end
               item
                 ClickCount = ccAny
                 ClickDir = cdDown
@@ -1688,20 +1729,20 @@ object frmHelpGenerator: TfrmHelpGenerator
               end>
             MarkupInfo.Background = clNone
             MarkupInfo.Foreground = clGray
-            MouseActionsExpanded = <            
+            MouseActionsExpanded = <
               item
                 ClickCount = ccAny
                 ClickDir = cdDown
                 Command = emcCodeFoldCollaps
               end>
-            MouseActionsCollapsed = <            
+            MouseActionsCollapsed = <
               item
                 Shift = [ssCtrl]
                 ShiftMask = [ssCtrl]
                 ClickCount = ccAny
                 ClickDir = cdDown
                 Command = emcCodeFoldExpand
-              end            
+              end
               item
                 ShiftMask = [ssCtrl]
                 ClickCount = ccAny
@@ -1735,29 +1776,28 @@ object frmHelpGenerator: TfrmHelpGenerator
   end
   object PanelLeft: TPanel
     Left = 0
-    Height = 573
+    Height = 588
     Top = 0
     Width = 208
     Align = alLeft
     BevelOuter = bvNone
-    ClientHeight = 573
+    ClientHeight = 588
     ClientWidth = 208
     TabOrder = 1
     object lbNavigation: TListBox
       Left = 0
-      Height = 514
-      Top = 59
+      Height = 543
+      Top = 45
       Width = 208
       Align = alClient
       ItemHeight = 0
       OnClick = lbNavigationClick
       ScrollWidth = 206
       TabOrder = 0
-      TopIndex = -1
     end
     object ButtonGenerate: TBitBtn
       Left = 10
-      Height = 39
+      Height = 25
       Hint = 'Generate documentation (F9)'
       Top = 10
       Width = 188
@@ -1801,6 +1841,13 @@ object frmHelpGenerator: TfrmHelpGenerator
     Filter = 'PasDoc GUI Settings (*.pds)|*.pds'
     FilterIndex = 0
     left = 496
+    top = 496
+  end
+  object OpenDialog3: TOpenDialog
+    Filter = 'All Files *.*|*.*'
+    FilterIndex = 0
+    Options = [ofHideReadOnly, ofAllowMultiSelect, ofFileMustExist, ofEnableSizing]
+    left = 917
     top = 496
   end
   object MainMenu1: TMainMenu


### PR DESCRIPTION
Adding the option to define additional files using the GUI and fixing a bug where FAdditionalFilesNames might be accessed before initialization.

I don't know why Lazarus changed all the width and height settings in the .lfm file, but I could not see any differences in the compiled .exe