### PR TITLE
Fix aspell call on WIN64

### DIFF
--- a/source/component/PasDoc_ProcessLineTalk.pas
+++ b/source/component/PasDoc_ProcessLineTalk.pas
@@ -36,6 +36,9 @@ unit PasDoc_ProcessLineTalk;
   {$ifdef WIN32}
     {$define HAS_PROCESS}
   {$endif}
+  {$ifdef WIN64}
+    {$define HAS_PROCESS}
+  {$endif}
 {$ELSE}
   {$ifdef LINUX}
     {$define HAS_PROCESS}
@@ -44,6 +47,9 @@ unit PasDoc_ProcessLineTalk;
     {$define HAS_PROCESS}
   {$endif}
   {$ifdef WIN32}
+    {$define HAS_PROCESS}
+  {$endif}
+  {$ifdef WIN64}
     {$define HAS_PROCESS}
   {$endif}
 {$ENDIF}


### PR DESCRIPTION
Calling aspell did not work on WIN64.
I fixed this simply by adding the compiler option to include the Process unit on WIN64 as well