### PR TITLE
Use v.Nu as HTML5 validator

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,14 @@
 default:
 	./run_all_tests.sh
 
+.PHONY: validate_html
+validate_html:
+	scripts/validate_html.sh
+
+.PHONY: validate_simplexml
+validate_simplexml:
+	scripts/validate_simplexml.sh
+
 .PHONY: clean
 clean:
 	rm -Rf \

--- a/tests/README.md
+++ b/tests/README.md
@@ -158,11 +158,18 @@ export USE_DIFF_TO_COMPARE=true
 - `scripts/validate_html.sh`
 
    This is an automatic test that makes html docs for all test units
-   and validates them using sgml validator.
-   onsgmls program must be installed for this to work.
+   and validates them using v.Nu validator.
 
-   Links how to install onsgmls may be found here
-   [https://github.com/pasdoc/pasdoc/wiki/HtmlOutput].
+   For this to work, vnu has to be available at $PATH. This can be archieved
+   by downloading the most recent version from [here](https://github.com/validator/validator/releases)
+   and then adding the following wrapper script to your bin directory:
+
+   ```
+   #!/bin/bash
+   exec java  -jar /path/to/vnu.jar "$@"
+   ```
+
+   On macOS, v.Nu can be installed using Homebrew simply by running `brew install vnu`.
 
 - `scripts/validate_simplexml.sh`
 

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -42,9 +42,8 @@ fi
 
 # validation -----------------------------------------------------------------
 
-# Validate testcases_output/html, requires onsgmls installed
-# This is unfortunately not working for HTML 5 now.
-# scripts/validate_html.sh
+# Validate testcases_output/html, requires vnu installed
+#scripts/validate_html.sh
 
 # Validate testcases_output/simplexml, requires xmllint installed
 scripts/validate_simplexml.sh

--- a/tests/scripts/validate_html.sh
+++ b/tests/scripts/validate_html.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
 set -eu
 
-# This scripts runs onsgmls to check every *.html file in html/ subdirectory,
+# This scripts runs v.Nu to check every *.html file in html/ subdirectory,
 # recursively.
 # It's meant to be run using `make validate_html' in parent directory.
 #
 # See ../README for comments.
-#
-# TODO: This is not really useful for now, as it doesn't validate HTML 5.
-# Fixes (to make onsgmls validate HTML 5, or use different validator
-# than onsgmls) welcome.
 
-# check if onsgmls is available and fail otherwise
-which onsgmls
+# check if vnu is available and fail otherwise
+command -v vnu >/dev/null 2>&1 || { printf "%s\n" \
+    "v.Nu has to be installed for HTML validation!" \
+    "See the README.md inside the tests directory to learn how..." 1>&2; exit 1; }
 
-find testcases_output/html/ -iname '*.html' \
-  -exec sh -c 'echo ---- Validating {}' ';' \
-  -exec onsgmls -s -e -g '{}' ';'
+vnu --skip-non-html --format text testcases_output/html/


### PR DESCRIPTION
Using [v.Nu](https://github.com/validator/validator/) as HTML5 validator.

v.Nu is a written in Java, so in order to run it easily, a wrapper script called `vnu` like

```
#!/bin/bash
exec java  -jar /path/to/vnu.jar "$@"
``` 

is needed at a location in `$PATH`.

Running the validator, it throws a couple of warnings and errors, but I have not looked at them in detail yet. This is why I didn't include the `validator_html.sh` in `run_all_tests.sh` yet but instead added a make target for this test (`make validate_html`) to call the validator specifically.