### PR TITLE
Added option "ignore-marker" to skip all comments starting with this marker

### DIFF
--- a/source/component/PasDoc_Base.pas
+++ b/source/component/PasDoc_Base.pas
@@ -88,6 +88,7 @@ type
     FUnits: TPasUnits;
     FVerbosity: Cardinal;
     FCommentMarkers: TStringList;
+    FIgnoreMarkers: TStringList;
     FGenerator: TDocGenerator;
     FShowVisibilities: TVisibilities;
     FMarkerOptional: boolean;
@@ -111,6 +112,7 @@ type
     procedure SetStarOnly(const Value: boolean);
     function GetStarOnly: boolean;
     procedure SetCommentMarkers(const Value: TStringList);
+    procedure SetIgnoreMarkers(const Value: TStringList);
 
     { Creates a @link(TPasUnit) object from the stream and adds it to
       @link(FUnits). }
@@ -191,6 +193,7 @@ type
       default DEFAULT_VERBOSITY_LEVEL;
     property StarOnly: boolean read GetStarOnly write SetStarOnly stored false;
     property CommentMarkers: TStringList read FCommentMarkers write SetCommentMarkers;
+    property IgnoreMarkers: TStringList read FIgnoreMarkers write SetIgnoreMarkers;
     property MarkerOptional: boolean read FMarkerOptional write FMarkerOptional
       default false;
     property IgnoreLeading: string read FIgnoreLeading write FIgnoreLeading;
@@ -253,6 +256,7 @@ begin
 
   FGenerator := nil;
   FCommentMarkers := TStringList.Create;
+  FIgnoreMarkers := TStringList.Create;
   FUnits := TPasUnits.Create(True);
 end;
 
@@ -261,6 +265,7 @@ end;
 destructor TPasDoc.Destroy;
 begin
   FCommentMarkers.Free;
+  FIgnoreMarkers.Free;
   FDescriptionFileNames.Free;
   FDirectives.Free;
   FIncludeDirectories.Free;
@@ -332,6 +337,7 @@ begin
     p.ShowVisibilities := ShowVisibilities;
     p.ImplicitVisibility := ImplicitVisibility;
     p.CommentMarkers := CommentMarkers;
+    p.IgnoreMarkers := IgnoreMarkers;
     p.MarkersOptional := MarkerOptional;
     p.IgnoreLeading := IgnoreLeading;
 
@@ -767,6 +773,11 @@ end;
 procedure TPasDoc.SetCommentMarkers(const Value: TStringList);
 begin
   FCommentMarkers.Assign(Value);
+end;
+
+procedure TPasDoc.SetIgnoreMarkers(const Value: TStringList);
+begin
+  FIgnoreMarkers.Assign(Value);
 end;
 
 procedure TPasDoc.HandleExternalFile(const FileName: string;

--- a/source/console/PasDoc_Main.pas
+++ b/source/console/PasDoc_Main.pas
@@ -67,6 +67,7 @@ type
     OptionLinkGVClasses: TStringOption;
     OptionVisibleMembers: TSetOption;
     OptionCommentMarker: TStringOptionList;
+    OptionIgnoreMarker: TStringOptionList;
     OptionMarkerOptional: TBoolOption;
     OptionIgnoreLeading: TStringOption;
     OptionCacheDir: TStringOption;
@@ -206,6 +207,10 @@ begin
   OptionCommentMarker := TStringOptionList.Create(#0, 'marker');
   OptionCommentMarker.Explanation := 'Parse only {<marker>, (*<marker> and //<marker> comments. Overrides the staronly option, which is a shortcut for ''--marker=**''';
   AddOption(OptionCommentMarker);
+
+  OptionIgnoreMarker := TStringOptionList.Create(#0, 'ignore-marker');
+  OptionIgnoreMarker.Explanation := 'Skip comments starting with <marker> (that is, {<marker>, (*<marker> and //<marker> comments)';
+  AddOption(OptionIgnoreMarker);
 
   OptionMarkerOptional := TBoolOption.Create(#0, 'marker-optional');
   OptionMarkerOptional.Explanation := 'Do not require the markers given in --marker but remove them from the comment if they exist.';
@@ -502,6 +507,9 @@ begin
 
   if OptionCommentMarker.WasSpecified then begin
     PasDoc.CommentMarkers.Assign(OptionCommentMarker.Values);
+  end;
+  if OptionIgnoreMarker.WasSpecified then begin
+    PasDoc.IgnoreMarkers.Assign(OptionIgnoreMarker.Values);
   end;
   if OptionStarOnly.TurnedOn then
     PasDoc.StarOnly := true;

--- a/tests/scripts/mk_tests.sh
+++ b/tests/scripts/mk_tests.sh
@@ -210,6 +210,7 @@ all_tests_for_current_format ()
   mk_test ok_date ok_date.pas
   mk_test ok_if_expressions ok_if_expressions.pas
   mk_test ok_prefix_identifier ok_prefix_identifier.pas
+  mk_test ok_ignore_marker ok_ignore_marker.pas --ignore-marker ~~ --ignore-marker TODO
 }
 
 # parse params ----------------------------------------

--- a/tests/testcases/ok_ignore_marker.pas
+++ b/tests/testcases/ok_ignore_marker.pas
@@ -1,0 +1,17 @@
+unit ok_ignore_marker;
+
+interface
+
+//~~ Constants ~~ (this must be ignored)
+const
+  A = 1;
+  B = 1;
+{~~ Types ~~ (this one too)}
+type
+  T = T;
+//TODO: add some code (and this one)
+procedure P;
+
+implementation
+
+end.


### PR DESCRIPTION
Useful for comments not intended for documenting, i.e. logical region titles like `//~ here go utilities ~` (`--ignore-marker ~`) or TODOs `{TODO add some code here }` (`--ignore-marker TODO`)
