### PR TITLE
Various enhancements

### DIFF
--- a/source/component/PasDoc_TagManager.pas
+++ b/source/component/PasDoc_TagManager.pas
@@ -538,7 +538,10 @@ const
       (Open: '*';    Close: '*';    PasDocTag: 'italic'),
       (Open: '_';    Close: '_';    PasDocTag: 'italic')
     );
-
+  // Set of chars markdown blocks could start with. To speedup checking
+  // All first chars of MarkdownBlocks[x].Open must be here. This could be automated
+  // but it's not so complicated to keep this set actual
+  MarkdownBlockStartChars = ['`', '*', '_'];
   MarkdownUListMarkers = ['-', '*'];
   MarkdownOListMarkers = ['0'..'9'];
   // Set of chars markdown lists could start with. To speedup checking
@@ -630,9 +633,9 @@ var
   i, MdBlockIdx: Integer;
 begin
   Result := False;
-  Parameters := '';
 
   // check if we have markdown block opening
+  if not SCharIs(Description, Offset, MarkdownBlockStartChars) then Exit;  // Fast check
   MdBlockIdx := -1;
   for i := Low(MarkdownBlocks) to High(MarkdownBlocks) do
     if Copy(Description, Offset, Length(MarkdownBlocks[i].Open)) = MarkdownBlocks[i].Open then

--- a/source/console/PasDoc_Main.pas
+++ b/source/console/PasDoc_Main.pas
@@ -418,7 +418,7 @@ procedure TPasdocOptions.InterpretCommandline(PasDoc: TPasDoc);
       on E: Exception do
       begin
         E.Message :=
-          'Error when opening file for "--latex-head" option: ' + E.Message;
+          'Error when opening file for "--'+OptionLatexHead.LongForm+'" option: ' + E.Message;
         raise;
       end;
     end;
@@ -499,13 +499,13 @@ begin
   if OptionUseTipueSearch.TurnedOn then begin
     if not (PasDoc.Generator is TGenericHTMLDocGenerator) then begin
       raise EInvalidCommandLine.Create(
-        'You can''t specify --use-tipue-search option for non-html output formats');
+        'You can''t specify "--'+OptionUseTipueSearch.LongForm+'" option for non-html output formats');
     end;
   end;
 
   if OptionHtmlHelpContents.Value <> '' then begin
     if not (PasDoc.Generator is THTMLHelpDocGenerator) then begin
-      raise EInvalidCommandLine.Create('You can specify --html-help-contents' +
+      raise EInvalidCommandLine.Create('You can specify "--'+OptionHtmlHelpContents.LongForm+'"' +
         ' option only for HTMLHelp output format');
     end;
   end;
@@ -560,7 +560,7 @@ begin
   if SameText(OptionLinkLook.Value, 'stripped') then
     PasDoc.Generator.LinkLook := llStripped else
     raise EInvalidCommandLine.CreateFmt(
-      'Invalid argument for "--link-look" option : "%s"',
+      'Invalid argument for "--'+OptionLinkLook.LongForm+'" option : "%s"',
       [OptionLinkLook.Value]);
 
   if OptionFullLink.TurnedOn then
@@ -579,7 +579,7 @@ begin
   if OptionLatexHead.Value <> '' then begin
     if not (PasDoc.Generator is TTexDocGenerator) then begin
       raise EInvalidCommandLine.Create(
-        'You can only use the "latex-head" option with LaTeX output.');
+        'You can only use the "--'+OptionLatexHead.LongForm+'" option with LaTeX output.');
     end;
   end;
 
@@ -590,7 +590,7 @@ begin
   if SameText(OptionImplicitVisibility.Value, 'implicit') then
     PasDoc.ImplicitVisibility := ivImplicit else
     raise EInvalidCommandLine.CreateFmt(
-      'Invalid argument for "--implicit-visibility" option : "%s"',
+      'Invalid argument for "--'+OptionImplicitVisibility.LongForm+'" option : "%s"',
       [OptionImplicitVisibility.Value]);
 
   PasDoc.HandleMacros := not OptionNoMacro.TurnedOn;

--- a/tests/scripts/mk_tests.sh
+++ b/tests/scripts/mk_tests.sh
@@ -221,7 +221,7 @@ all_tests_for_current_format ()
     test_links_to_dot_names/test_dot.two.dots.pas \
     test_links_to_dot_names/test_dot.one_dot.pas \
     test_links_to_dot_names/test_dot_no_dot.pas
-  mk_test ok_ignore_marker ok_ignore_marker.pas --ignore-marker ~~ --ignore-marker TODO
+  mk_test ok_ignore_marker ok_ignore_marker.pas --ignore-marker=~~ --ignore-marker=TODO
   mk_test ok_skip_ifdefed_out ok_skip_ifdefed_out.pas
   mk_test warning_back_comments warning_back_comments.pas
   mk_test ok_longcode_indentation ok_longcode_indentation.pas

--- a/tests/testcases_output/html/ok_latex_head/PASDOC-OUTPUT
+++ b/tests/testcases_output/html/ok_latex_head/PASDOC-OUTPUT
@@ -1,1 +1,1 @@
-Fatal Error: EInvalidCommandLine: You can only use the "latex-head" option with LaTeX output.
+Fatal Error: EInvalidCommandLine: You can only use the "--latex-head" option with LaTeX output.

--- a/tests/testcases_output/htmlhelp/ok_latex_head/PASDOC-OUTPUT
+++ b/tests/testcases_output/htmlhelp/ok_latex_head/PASDOC-OUTPUT
@@ -1,1 +1,1 @@
-Fatal Error: EInvalidCommandLine: You can only use the "latex-head" option with LaTeX output.
+Fatal Error: EInvalidCommandLine: You can only use the "--latex-head" option with LaTeX output.

--- a/tests/testcases_output/simplexml/ok_latex_head/PASDOC-OUTPUT
+++ b/tests/testcases_output/simplexml/ok_latex_head/PASDOC-OUTPUT
@@ -1,1 +1,1 @@
-Fatal Error: EInvalidCommandLine: You can only use the "latex-head" option with LaTeX output.
+Fatal Error: EInvalidCommandLine: You can only use the "--latex-head" option with LaTeX output.


### PR DESCRIPTION
- Console: option names in exceptions are taken from LongForm fields thus avoiding duplication and inconsistency should an option be renamed
- Tests: modified test script, tildes seem to be special to bash so it hangs by 20 secs on unquoted `~~` running `ok_ignore_marker` test (at least on Windows). Anyway setting options with equation sign is consistent with the rest testcases
- Markdown block check now uses fast preliminary check to filter out most of characters that are not markers of markdown blocks