### PR TITLE
Implement --lowercase-keywords command-line option

### DIFF
--- a/source/component/PasDoc_Gen.pas
+++ b/source/component/PasDoc_Gen.pas
@@ -264,6 +264,12 @@ type
       default is false }
     FExcludeGenerator: boolean;
     FIncludeCreationTime: boolean;
+
+    { If false, the first character of literal tags like 'false' and 'nil' will be upcased.
+      Otherwise all characters will be lowercased.
+      default is false }
+    FUseLowercaseKeywords: boolean;
+
     { the output stream that is currently written to; depending on the
       output format, more than one output stream will be necessary to
       store all documentation }
@@ -925,6 +931,10 @@ type
     property IncludeCreationTime: Boolean
       read FIncludeCreationTime write FIncludeCreationTime default false;
 
+    { Setting to define how literal tag keywords should appear in documentaion. }
+    property UseLowercaseKeywords: Boolean
+      read FUseLowercaseKeywords write FUseLowercaseKeywords default false;
+
     { Title of the documentation, supplied by user. May be empty.
       See @link(TPasDoc.Title). }
     property Title: string read FTitle write FTitle;
@@ -1289,8 +1299,11 @@ procedure TDocGenerator.HandleLiteralTag(
   EnclosingTag: TTag; var EnclosingTagData: TObject;
   const TagParameter: string; var ReplaceStr: string);
 begin
-  ReplaceStr := CodeString(UpCase(ThisTag.Name[1]) +
-    Copy(ThisTag.Name, 2, MaxInt));
+  if UseLowercaseKeywords then
+    ReplaceStr := CodeString(ThisTag.Name)
+  else
+    ReplaceStr := CodeString(UpCase(ThisTag.Name[1]) +
+      Copy(ThisTag.Name, 2, MaxInt));
 end;
 
 procedure TDocGenerator.HandleInheritedClassTag(
@@ -2664,6 +2677,7 @@ begin
   FClassHierarchy := nil;
   FExcludeGenerator := false;
   FIncludeCreationTime := false;
+  FUseLowercaseKeywords := false;
   FLanguage := TPasDocLanguages.Create;
   FAbbreviations := TStringList.Create;
   FAbbreviations.Duplicates := dupIgnore;

--- a/source/console/PasDoc_Main.pas
+++ b/source/console/PasDoc_Main.pas
@@ -59,6 +59,7 @@ type
     OptionStarOnly,
     OptionExcludeGenerator,
     OptionIncludeCreationTime,
+    OptionUseLowercaseKeywords,
     OptionNumericFilenames,
     OptionWriteUsesList,
     OptionWriteGVUses,
@@ -208,6 +209,10 @@ begin
   OptionIncludeCreationTime := TBoolOption.Create(#0, 'include-creation-time');
   OptionIncludeCreationTime.Explanation := 'Include creation time in the docs';
   AddOption(OptionIncludeCreationTime);
+
+  OptionUseLowercaseKeywords := TBoolOption.Create('k', 'lowercase-keywords');
+  OptionUseLowercaseKeywords.Explanation := 'Lowercase all literal tag keywords';
+  AddOption(OptionUseLowercaseKeywords);
 
   OptionLanguage := TStringOption.Create('L', 'language');
   OptionLanguage.Explanation := 'Output language. Valid languages are: ' + LineEnding;
@@ -520,6 +525,7 @@ begin
 
   PasDoc.Generator.ExcludeGenerator := OptionExcludeGenerator.TurnedOn;
   PasDoc.Generator.IncludeCreationTime := OptionIncludeCreationTime.TurnedOn;
+  PasDoc.Generator.UseLowercaseKeywords := OptionUseLowercaseKeywords.TurnedOn;
   PasDoc.Generator.WriteUsesClause := OptionWriteUsesList.TurnedOn;
 
   if OptionUseTipueSearch.TurnedOn then begin


### PR DESCRIPTION
- allows to control how the literal tags nil,false,true appear in documentation
- default setting is false for backward compatibility (first letter upcased)
- if true, the words are lowercased

closes feature request #89