### PR TITLE
Add support for new URL tag

### DIFF
--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -282,6 +282,7 @@ type
     function LineBreak: string; override;
 
     function URLLink(const URL: string): string; override;
+    function URLLink(const URL, LinkDisplay: string): string; override;
 
     procedure WriteExternalCore(const ExternalItem: TExternalItem;
       const Id: TTranslationID); override;
@@ -2270,6 +2271,18 @@ end;
 function TGenericHTMLDocGenerator.URLLink(const URL: string): string;
 begin
   Result := MakeLink(URL, ConvertString(URL), '');
+end;
+
+function TGenericHTMLDocGenerator.URLLink(const URL, LinkDisplay: string): string;
+var
+  Link: String;
+begin
+  Link := FixEmailaddressWithoutMailTo(URL);
+
+  if LinkDisplay <> '' then
+    Result := MakeLink(Link, ConvertString(LinkDisplay), '')
+  else
+    Result := MakeLink(Link, ConvertString(URL), '');
 end;
 
 procedure TGenericHTMLDocGenerator.WriteExternalCore(

--- a/source/component/PasDoc_GenLatex.pas
+++ b/source/component/PasDoc_GenLatex.pas
@@ -194,6 +194,7 @@ type
     function LineBreak: string; override;
 
     function URLLink(const URL: string): string; override;
+    function URLLink(const URL, LinkDisplay: string): string; override;
 
     procedure WriteExternalCore(const ExternalItem: TExternalItem;
       const Id: TTranslationID); override;
@@ -1523,6 +1524,31 @@ begin
        understand \usepackage{hyperref} at all) *)
     Result := ConvertString(URL) else
     Result := '\href{' + EscapeURL(URL) + '}{' + ConvertString(URL) + '}';
+end;
+
+function TTexDocGenerator.URLLink(const URL, LinkDisplay: string): string;
+var
+  Link: String;
+begin
+  Link := FixEmailaddressWithoutMailTo(URL);
+
+  if LinkDisplay <> '' then
+  begin
+    if Latex2Rtf then
+      (* latex2rtf doesn't understand \href (well, actually it doesn't
+        understand \usepackage{hyperref} at all) *)
+      Result := ConvertString(Link + ' (' + LinkDisplay + ')') else
+      Result := '\href{' + EscapeURL(Link) + '}{' + ConvertString(LinkDisplay) + '}';
+  end
+  else
+  begin
+    if Latex2Rtf then
+    (* latex2rtf doesn't understand \href (well, actually it doesn't
+       understand \usepackage{hyperref} at all) *)
+    Result := ConvertString(Link) else
+    Result := '\href{' + EscapeURL(Link) + '}{' + ConvertString(URL) + '}';
+  end;
+
 end;
 
 procedure TTexDocGenerator.WriteExternalCore(


### PR DESCRIPTION
- allows to specify an URL with and without a display name
- supports email addresses (with and without mailto: prefix)

closes feat-req #36 and allows to implement #55 now

-----
following combinations are working:
```
@url(https://github.com/pasdoc/pasdoc/issues/36 this issue is urgent)
@url(https://github.com/pasdoc/pasdoc/issues/55)
@url(https://www.gnutls.org GnuTLS library)

@url(admin@github.com)
@url(fpc-devel@lists.freepascal.org FPC Mailing List)

@url(mailto:admin@github.com)
@url(mailto:fpc-devel@lists.freepascal.org FPC Mailing List)
```