### PR TITLE
 Add support for @warning and @note tag 

### DIFF
--- a/source/component/PasDoc_Gen.pas
+++ b/source/component/PasDoc_Gen.pas
@@ -346,6 +346,12 @@ type
     procedure HandleCodeTag(ThisTag: TTag; var ThisTagData: TObject;
       EnclosingTag: TTag; var EnclosingTagData: TObject;
       const TagParameter: string; var ReplaceStr: string);
+    procedure HandleWarningTag(ThisTag: TTag; var ThisTagData: TObject;
+      EnclosingTag: TTag; var EnclosingTagData: TObject;
+      const TagParameter: string; var ReplaceStr: string);
+    procedure HandleNoteTag(ThisTag: TTag; var ThisTagData: TObject;
+      EnclosingTag: TTag; var EnclosingTagData: TObject;
+      const TagParameter: string; var ReplaceStr: string);
     procedure HandleLiteralTag(ThisTag: TTag; var ThisTagData: TObject;
       EnclosingTag: TTag; var EnclosingTagData: TObject;
       const TagParameter: string; var ReplaceStr: string);
@@ -827,6 +833,12 @@ type
     { This returns Text formatted using italic font.
       Analogous to @link(FormatBold). }
     function FormatItalic(const Text: string): string; virtual;
+
+    { This returns Text using bold font by calling FormatBold(Text). }
+    function FormatWarning(const Text: string): string; virtual;
+
+    { This returns Text using italic font by calling FormatItalic(Text). }
+    function FormatNote(const Text: string): string; virtual;
 
     { This returns Text preserving spaces and line breaks.
       Note that Text passed here is not yet converted with ConvertString.
@@ -1432,6 +1444,22 @@ begin
   ReplaceStr := CodeString(TagParameter);
 end;
 
+procedure TDocGenerator.HandleWarningTag(
+  ThisTag: TTag; var ThisTagData: TObject;
+  EnclosingTag: TTag; var EnclosingTagData: TObject;
+  const TagParameter: string; var ReplaceStr: string);
+begin
+  ReplaceStr := FormatWarning(TagParameter);
+end;
+
+procedure TDocGenerator.HandleNoteTag(
+  ThisTag: TTag; var ThisTagData: TObject;
+  EnclosingTag: TTag; var EnclosingTagData: TObject;
+  const TagParameter: string; var ReplaceStr: string);
+begin
+  ReplaceStr := FormatNote(TagParameter);
+end;
+
 procedure TDocGenerator.HandleBrTag(
   ThisTag: TTag; var ThisTagData: TObject;
   EnclosingTag: TTag; var EnclosingTagData: TObject;
@@ -1960,6 +1988,15 @@ procedure TDocGenerator.ExpandDescriptions;
          toAllowNormalTextInside]);
       TTag.Create(TagManager, 'italic',
         nil, {$IFDEF FPC}@{$ENDIF} HandleItalicTag,
+        [toParameterRequired, toRecursiveTags, toAllowOtherTagsInsideByDefault,
+         toAllowNormalTextInside]);
+
+      TTag.Create(TagManager, 'warning',
+        nil, {$IFDEF FPC}@{$ENDIF} HandleWarningTag,
+        [toParameterRequired, toRecursiveTags, toAllowOtherTagsInsideByDefault,
+         toAllowNormalTextInside]);
+      TTag.Create(TagManager, 'note',
+        nil, {$IFDEF FPC}@{$ENDIF} HandleNoteTag,
         [toParameterRequired, toRecursiveTags, toAllowOtherTagsInsideByDefault,
          toAllowNormalTextInside]);
 
@@ -3669,6 +3706,16 @@ end;
 function TDocGenerator.FormatItalic(const Text: string): string;
 begin
   Result := Text;
+end;
+
+function TDocGenerator.FormatWarning(const Text: string): string;
+begin
+  Result := FormatBold(Text);
+end;
+
+function TDocGenerator.FormatNote(const Text: string): string;
+begin
+  Result := FormatItalic(Text);
 end;
 
 function TDocGenerator.FormatPreformatted(const Text: string): string;

--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -2337,14 +2337,14 @@ end;
 
 function TGenericHTMLDocGenerator.FormatWarning(const Text: string): string;
 begin
-  Result := '<dl class="tag warning"><dt>' + FormatBold('Warning') + '</dt><dd>';
+  Result := '<dl class="tag warning"><dt>' + FormatBold(FLanguage.Translation[trWarningTag]) + '</dt><dd>';
   Result := Result + Text;
   Result := Result + '</dd></dl>';
 end;
 
 function TGenericHTMLDocGenerator.FormatNote(const Text: string): string;
 begin
-  Result := '<dl class="tag note"><dt>' + FormatBold('Note') + '</dt><dd>';
+  Result := '<dl class="tag note"><dt>' + FormatBold(FLanguage.Translation[trNoteTag]) + '</dt><dd>';
   Result := Result + Text;
   Result := Result + '</dd></dl>';
 end;

--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -300,6 +300,8 @@ type
     function FormatBold(const Text: string): string; override;
     function FormatItalic(const Text: string): string; override;
 
+    function FormatWarning(const Text: string): string; override;
+    function FormatNote(const Text: string): string; override;
     function FormatPreformatted(const Text: string): string; override;
 
     function FormatImage(FileNames: TStringList): string; override;
@@ -2331,6 +2333,20 @@ end;
 function TGenericHTMLDocGenerator.FormatItalic(const Text: string): string;
 begin
   Result := '<em>' + Text + '</em>';
+end;
+
+function TGenericHTMLDocGenerator.FormatWarning(const Text: string): string;
+begin
+  Result := '<dl class="tag warning"><dt>' + FormatBold('Warning') + '</dt><dd>';
+  Result := Result + Text;
+  Result := Result + '</dd></dl>';
+end;
+
+function TGenericHTMLDocGenerator.FormatNote(const Text: string): string;
+begin
+  Result := '<dl class="tag note"><dt>' + FormatBold('Note') + '</dt><dd>';
+  Result := Result + Text;
+  Result := Result + '</dd></dl>';
 end;
 
 function TGenericHTMLDocGenerator.FormatPreformatted(

--- a/source/component/PasDoc_GenLatex.pas
+++ b/source/component/PasDoc_GenLatex.pas
@@ -651,8 +651,8 @@ procedure TTexDocGenerator.WriteWarningAndNoteTagDefinition;
 begin
   WriteDirect('% definitons for warning and note tag',true);
   WriteDirect('\usepackage[most]{tcolorbox}',true);
-  WriteBoxDefinition('tcbwarning', 'Warning', 'red');
-  WriteBoxDefinition('tcbnote', 'Note', 'yellow');
+  WriteBoxDefinition('tcbwarning', FLanguage.Translation[trWarningTag], 'red');
+  WriteBoxDefinition('tcbnote', FLanguage.Translation[trNoteTag], 'yellow');
 end;
 
 { ---------------------------------------------------------------------------- }

--- a/source/component/PasDoc_GenLatex.pas
+++ b/source/component/PasDoc_GenLatex.pas
@@ -160,6 +160,10 @@ type
     { Writes dates Created and LastMod at heading level HL to output
       (if at least one the two has a value assigned). }
     procedure WriteDates(const HL: integer; const Created, LastMod: string);
+
+    { Writes include and style definiton for @warning and @note tag }
+    procedure WriteWarningAndNoteTagDefinition;
+
     procedure SetLatexHead(const Value: TStrings);
     function FormatHeading(HL: integer; const s: string): string;
   protected
@@ -226,6 +230,8 @@ Latex DocGenerators.}
     function FormatBold(const Text: string): string; override;
     function FormatItalic(const Text: string): string; override;
 
+    function FormatWarning(const Text: string): string; override;
+    function FormatNote(const Text: string): string; override;
     function FormatPreformatted(const Text: string): string; override;
 
     function FormatImage(FileNames: TStringList): string; override;
@@ -617,6 +623,36 @@ begin
     WriteDirectLine(LastMod);
     WriteEndOfParagraph;
   end;
+end;
+
+procedure TTexDocGenerator.WriteWarningAndNoteTagDefinition;
+  procedure WriteBoxDefinition(const BoxName, Heading, VertLineColor: String);
+  begin
+    WriteDirect('\newtcolorbox{' + BoxName + '}{',true);
+    WriteDirect(' breakable,',true);
+    WriteDirect(' enhanced jigsaw,',true);
+    WriteDirect(' top=0pt,',true);
+    WriteDirect(' bottom=0pt,',true);
+    WriteDirect(' titlerule=0pt,',true);
+    WriteDirect(' bottomtitle=0pt,',true);
+    WriteDirect(' rightrule=0pt,',true);
+    WriteDirect(' toprule=0pt,',true);
+    WriteDirect(' bottomrule=0pt,',true);
+    WriteDirect(' colback=white,',true);
+    WriteDirect(' arc=0pt,',true);
+    WriteDirect(' outer arc=0pt,',true);
+    WriteDirect(' title style={white},',true);
+    WriteDirect(' fonttitle=\color{black}\bfseries,',true);
+    WriteDirect(' left=8pt,',true);
+    WriteDirect(' colframe=' + VertLineColor + ',',true);
+    WriteDirect(' title={' + Heading + ':},',true);
+    WriteDirect('}',true);
+  end;
+begin
+  WriteDirect('% definitons for warning and note tag',true);
+  WriteDirect('\usepackage[most]{tcolorbox}',true);
+  WriteBoxDefinition('tcbwarning', 'Warning', 'red');
+  WriteBoxDefinition('tcbnote', 'Note', 'yellow');
 end;
 
 { ---------------------------------------------------------------------------- }
@@ -1278,6 +1314,10 @@ begin
   Title := ConvertString(Title);
   WritePDFDocInfo(Title);
   WriteDirect('',true);
+
+  WriteWarningAndNoteTagDefinition;
+
+  WriteDirect('',true);
   WriteDirect('\begin{document}',true);
   if not Flatex2rtf then
   begin
@@ -1635,6 +1675,16 @@ end;
 function TTexDocGenerator.FormatItalic(const Text: string): string;
 begin
   Result := '\textit{' + Text + '}';
+end;
+
+function TTexDocGenerator.FormatWarning(const Text: string): string;
+begin
+  Result := '\begin{tcbwarning}' + Text + '\end{tcbwarning}';
+end;
+
+function TTexDocGenerator.FormatNote(const Text: string): string;
+begin
+  Result := '\begin{tcbnote}' + Text + '\end{tcbnote}'
 end;
 
 function TTexDocGenerator.FormatPreformatted(const Text: string): string;

--- a/source/component/PasDoc_Languages.pas
+++ b/source/component/PasDoc_Languages.pas
@@ -204,6 +204,9 @@ type
     trDescriptions, //<section heading for detailed descriptions
     trName,
     trValues,
+//tags with inbuilt heading
+    trWarningTag,
+    trNoteTag,
 
   //empty tables
     trNone,

--- a/source/component/lang/PasDoc_Languages_Bosnia_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Bosnia_1250.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Ime',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ništa',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Bosnia_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Bosnia_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Ime',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ništa',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Brasilian_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Brasilian_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nome',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nenhum',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Brasilian_utf8.inc
+++ b/source/component/lang/PasDoc_Languages_Brasilian_utf8.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Descrição detalhada',
     {trName} 'Nome',
     {trValues} 'Valores',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nenhum',
     {trNoCIOs} 'A unit não contém quaisquer classes, interfaces, objetos ou registros',

--- a/source/component/lang/PasDoc_Languages_Brasilian_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Brasilian_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} 'Descrição detalhada',
     {trName} 'Nome',
     {trValues} 'Valores',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nenhum',
     {trNoCIOs} 'A unit não contém quaisquer classes, interfaces, objetos ou registros',

--- a/source/component/lang/PasDoc_Languages_Bulgarian_utf8.inc
+++ b/source/component/lang/PasDoc_Languages_Bulgarian_utf8.inc
@@ -82,6 +82,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Име',
     {trValues} 'Стойност(и)',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Няма',
     {trNoCIOs} 'Модулите не съдържат класове, интерфейси, обекти и записи',

--- a/source/component/lang/PasDoc_Languages_Bulgarian_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Bulgarian_utf8_bom.inc
@@ -82,6 +82,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Име',
     {trValues} 'Стойност(и)',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Няма',
     {trNoCIOs} 'Модулите не съдържат класове, интерфейси, обекти и записи',

--- a/source/component/lang/PasDoc_Languages_Catalan_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Catalan_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nom',
     {trValues} 'Valors',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Cap',
     {trNoCIOs} 'Les unitats no contenen cap classe, interfície, objecte ni registre.',

--- a/source/component/lang/PasDoc_Languages_Catalan_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Catalan_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} 'Descripció detallada', //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nom', //'Nom',
     {trValues} 'Valors', //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Cap',
     {trNoCIOs} 'Les unitats no contenen classes, interfaces, objectes ni registres.', //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Chinese_gb2312.inc
+++ b/source/component/lang/PasDoc_Languages_Chinese_gb2312.inc
@@ -81,6 +81,9 @@ RTransTable = (
     {trDescriptions} '描述',
     {trName} '名称',
     {trValues} '值',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} '无',
     {trNoCIOs} '不包含任何类、接口、对象和记录的单元.',

--- a/source/component/lang/PasDoc_Languages_Chinese_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Chinese_utf8_bom.inc
@@ -81,6 +81,9 @@ RTransTable = (
     {trDescriptions} '描述',
     {trName} '名称',
     {trValues} '值',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} '无',
     {trNoCIOs} '不包含任何类、接口、对象和记录的单元.',

--- a/source/component/lang/PasDoc_Languages_Croatia_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Croatia_1250.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Detaljni opis',
     {trName} 'Ime',
     {trValues} 'Vrijednosti', //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ništa',
     {trNoCIOs} 'Datoteka ne sadrži klase, suèelja, objekte ili zapise.',

--- a/source/component/lang/PasDoc_Languages_Croatia_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Croatia_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} 'Detaljni opis',
     {trName} 'Ime',
     {trValues} 'Vrijednosti', //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ništa',
     {trNoCIOs} 'Datoteka ne sadrži klase, sučelja, objekte ili zapise.',

--- a/source/component/lang/PasDoc_Languages_Czech_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Czech_1250.inc
@@ -92,6 +92,9 @@ RTransTable = (
     {trDescriptions} strToDo,
     {trName} 'Název',
     {trValues} 'Hodnoty',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nic',
     {trNoCIOs} 'Unity neobsahují žádné tøídy, rozhraní, objekty nebo recordy.',

--- a/source/component/lang/PasDoc_Languages_Czech_iso_8859_2.inc
+++ b/source/component/lang/PasDoc_Languages_Czech_iso_8859_2.inc
@@ -92,6 +92,9 @@ RTransTable = (
     {trDescriptions} strToDo,
     {trName} 'Název',
     {trValues} 'Hodnoty',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nic',
     {trNoCIOs} 'Unity neobsahují ¾ádné tøídy, rozhraní, objekty nebo recordy.',

--- a/source/component/lang/PasDoc_Languages_Czech_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Czech_utf8_bom.inc
@@ -92,6 +92,9 @@ RTransTable = (
     {trDescriptions} strToDo,
     {trName} 'Název',
     {trValues} 'Hodnoty',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nic',
     {trNoCIOs} 'Unity neobsahují žádné třídy, rozhraní, objekty nebo recordy.',

--- a/source/component/lang/PasDoc_Languages_Danish_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Danish_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Navn',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} 'Advarsel',
+    {trNoteTag} 'Bemærk',
   //empty
     {trNone} 'Ingen',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Danish_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Danish_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Navn',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} 'Advarsel',
+    {trNoteTag} 'Bemærk',
   //empty
     {trNone} 'Ingen',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Dutch_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Dutch_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Naam',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Geen',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Dutch_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Dutch_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Naam',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Geen',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_English_utf8.inc
+++ b/source/component/lang/PasDoc_Languages_English_utf8.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Detailed Descriptions',
     {trName} 'Name',
     {trValues} 'Values',
+  //tags with inbuilt heading
+    {trWarningTag} 'Warning',
+    {trNoteTag} 'Note',
   //empty
     {trNone} 'None',
     {trNoCIOs} 'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_English_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_English_utf8_bom.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Detailed Descriptions',
     {trName} 'Name',
     {trValues} 'Values',
+  //tags with inbuilt heading
+    {trWarningTag} 'Warning',
+    {trNoteTag} 'Note',
   //empty
     {trNone} 'None',
     {trNoCIOs} 'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_French_1252.inc
+++ b/source/component/lang/PasDoc_Languages_French_1252.inc
@@ -78,6 +78,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nom',
     {trValues} 'Valeurs', //?
+  //tags with inbuilt heading
+    {trWarningTag} 'Attention',
+    {trNoteTag} 'Remarque',
   //empty
     {trNone} 'Aucun(e)(s)', //'Rien'?
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_French_ISO_8859_15.inc
+++ b/source/component/lang/PasDoc_Languages_French_ISO_8859_15.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strKeep, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nom',
     {trValues} 'Valeurs', //?
+  //tags with inbuilt heading
+    {trWarningTag} 'Attention',
+    {trNoteTag} 'Remarque',
   //empty
     {trNone} 'Aucun(e)(s)', //'Rien'?
     {trNoCIOs} 'L''unité ne contient ni classe, ni interface, ni objets, ni enregistrement.',

--- a/source/component/lang/PasDoc_Languages_French_utf8.inc
+++ b/source/component/lang/PasDoc_Languages_French_utf8.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strKeep, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nom',
     {trValues} 'Valeurs', //?
+  //tags with inbuilt heading
+    {trWarningTag} 'Attention',
+    {trNoteTag} 'Remarque',
   //empty
     {trNone} 'Aucun(e)(s)', //'Rien'?
     {trNoCIOs} 'L''unité ne contient ni classe, ni interface, ni objets, ni enregistrement.',

--- a/source/component/lang/PasDoc_Languages_French_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_French_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strKeep, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nom',
     {trValues} 'Valeurs', //?
+  //tags with inbuilt heading
+    {trWarningTag} 'Attention',
+    {trNoteTag} 'Remarque',
   //empty
     {trNone} 'Aucun(e)(s)', //'Rien'?
     {trNoCIOs} 'L''unité ne contient ni classe, ni interface, ni objets, ni enregistrement.',

--- a/source/component/lang/PasDoc_Languages_German_ISO_8859_15.inc
+++ b/source/component/lang/PasDoc_Languages_German_ISO_8859_15.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Ausführliche Beschreibungen',
     {trName} strKeep, //'Name',
     {trValues} 'Werte',
+  //tags with inbuilt heading
+    {trWarningTag} 'Warnung',
+    {trNoteTag} 'Hinweis',
   //empty
     {trNone} 'Keine',
     {trNoCIOs} 'Die Units enthalten keine Klassen, Interfaces, Objects oder Records.',

--- a/source/component/lang/PasDoc_Languages_German_utf8.inc
+++ b/source/component/lang/PasDoc_Languages_German_utf8.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Ausführliche Beschreibungen',
     {trName} strKeep, //'Name',
     {trValues} 'Werte',
+  //tags with inbuilt heading
+    {trWarningTag} 'Warnung',
+    {trNoteTag} 'Hinweis',
   //empty
     {trNone} 'Keine',
     {trNoCIOs} 'Die Units enthalten keine Klassen, Interfaces, Objects oder Records.',

--- a/source/component/lang/PasDoc_Languages_German_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_German_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} 'Ausführliche Beschreibungen',
     {trName} strKeep, //'Name',
     {trValues} 'Werte',
+  //tags with inbuilt heading
+    {trWarningTag} 'Warnung',
+    {trNoteTag} 'Hinweis',
   //empty
     {trNone} 'Keine',
     {trNoCIOs} 'Die Units enthalten keine Klassen, Interfaces, Objects oder Records.',

--- a/source/component/lang/PasDoc_Languages_Hungarian_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Hungarian_1250.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Név',
     {trValues} 'Értékek',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nincs',
     {trNoCIOs} 'Az egység nem tartalmaz osztályt, interfészt, objektumot, vagy rekordot.',

--- a/source/component/lang/PasDoc_Languages_Hungarian_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Hungarian_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Név',
     {trValues} 'Értékek',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nincs',
     {trNoCIOs} 'Az egység nem tartalmaz osztályt, interfészt, objektumot, vagy rekordot.',

--- a/source/component/lang/PasDoc_Languages_Indonesian_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Indonesian_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nama',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Tidak Ada',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Indonesian_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Indonesian_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nama',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Tidak Ada',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Italian_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Italian_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nome',
     {trValues} 'Valori',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nessuno',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Italian_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Italian_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nome',
     {trValues} 'Valori',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nessuno',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Javanese_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Javanese_1250.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Jeneng',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Mboten Wonten',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Javanese_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Javanese_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Jeneng',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Mboten Wonten',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Polish_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Polish_1250.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Szczegó³y', //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nazwa',
     {trValues} 'Wartoœci',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Brak',
     {trNoCIOs} 'Modu³ nie zawiera ¿adnych klas, interfejsów, obiektów ani rekordów.',

--- a/source/component/lang/PasDoc_Languages_Polish_iso_8859_2.inc
+++ b/source/component/lang/PasDoc_Languages_Polish_iso_8859_2.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Szczegó³y', //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nazwa',
     {trValues} 'Warto¶ci',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Brak',
     {trNoCIOs} 'Modu³ nie zawiera ¿adnych klas, interfejsów, obiektów ani rekordów.',

--- a/source/component/lang/PasDoc_Languages_Polish_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Polish_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} 'Szczegóły', //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nazwa',
     {trValues} 'Wartości',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Brak',
     {trNoCIOs} 'Moduł nie zawiera żadnych klas, interfejsów, obiektów ani rekordów.',

--- a/source/component/lang/PasDoc_Languages_Russian_1251.inc
+++ b/source/component/lang/PasDoc_Languages_Russian_1251.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Имя',
     {trValues} 'Значение',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Нет',
     {trNoCIOs} 'Модули не содержат классов, интерфейсов, объектов и записей.',

--- a/source/component/lang/PasDoc_Languages_Russian_866.inc
+++ b/source/component/lang/PasDoc_Languages_Russian_866.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Имя', //'Name',
     {trValues} 'Значение', //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Нет', //'None',
     {trNoCIOs} 'Модули не содержат классов, интерфейсов, объектов и записей.', //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Russian_koi8r.inc
+++ b/source/component/lang/PasDoc_Languages_Russian_koi8r.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Имя', //'Name',
     {trValues} 'Значение', //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Нет', //'None',
     {trNoCIOs} 'Модули не содержат классов, интерфейсов, объектов и записей.', //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Russian_utf8.inc
+++ b/source/component/lang/PasDoc_Languages_Russian_utf8.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Имя',
     {trValues} 'Значение',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Нет',
     {trNoCIOs} 'Модули не содержат классов, интерфейсов, объектов и записей.',

--- a/source/component/lang/PasDoc_Languages_Russian_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Russian_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Имя',
     {trValues} 'Значение',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Нет',
     {trNoCIOs} 'Модули не содержат классов, интерфейсов, объектов и записей.',

--- a/source/component/lang/PasDoc_Languages_Slovak_1250.inc
+++ b/source/component/lang/PasDoc_Languages_Slovak_1250.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Meno',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Niè',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Slovak_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Slovak_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Meno',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Nič',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Spanish_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Spanish_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} 'Descripción detallada', //? 'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nombre',
     {trValues} 'Valores',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ninguno',
     {trNoCIOs} 'Las unidades no contienen clases, interfaces, objetos ni registros.',

--- a/source/component/lang/PasDoc_Languages_Spanish_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Spanish_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} 'Descripción detallada', //? 'Descriptions', 'Detailed Descriptions'?
     {trName} 'Nombre',
     {trValues} 'Valores',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ninguno',
     {trNoCIOs} 'Las unidades no contienen clases, interfaces, objetos ni registros.',

--- a/source/component/lang/PasDoc_Languages_Swedish_1252.inc
+++ b/source/component/lang/PasDoc_Languages_Swedish_1252.inc
@@ -79,6 +79,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Namn',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ingen/inget.', //???
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Swedish_utf8_bom.inc
+++ b/source/component/lang/PasDoc_Languages_Swedish_utf8_bom.inc
@@ -79,6 +79,9 @@
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} 'Namn',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} 'Ingen/inget.', //???
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/lang/PasDoc_Languages_Template_New_Language.inc
+++ b/source/component/lang/PasDoc_Languages_Template_New_Language.inc
@@ -103,6 +103,9 @@ RTransTable = (
     {trDescriptions} strToDo, //'Descriptions', 'Detailed Descriptions'?
     {trName} strToDo, //'Name',
     {trValues} strToDo, //'Values',
+  //tags with inbuilt heading
+    {trWarningTag} strToDo,
+    {trNoteTag} strToDo,
   //empty
     {trNone} strToDo, //'None',
     {trNoCIOs} strToDo, //'The units do not contain any classes, interfaces, objects or records.',

--- a/source/component/pasdoc.css
+++ b/source/component/pasdoc.css
@@ -120,6 +120,20 @@ td.itemdesc { width:100%; }
 div.nodescription { color:red; }
 dl.parameters dt { color:blue; }
 
+/* style for warning and note tag */
+dl.tag.warning {
+  margin-left:-2px;
+  padding-left: 3px;
+  border-left:4px solid;
+  border-color: #FF0000;
+}
+dl.tag.note {
+  margin-left:-2px;
+  padding-left: 3px;
+  border-left:4px solid;
+  border-color: #D0C000;
+}
+
 /* Various browsers have various default styles for <h6>,
    sometimes ugly for our purposes, so it's best to set things
    like font-size and font-weight in out pasdoc.css explicitly. */

--- a/source/component/pasdoc.css.inc
+++ b/source/component/pasdoc.css.inc
@@ -122,6 +122,20 @@
 'div.nodescription { color:red; }' + LineEnding +
 'dl.parameters dt { color:blue; }' + LineEnding +
 '' + LineEnding +
+'/* style for warning and note tag */' + LineEnding +
+'dl.tag.warning {' + LineEnding +
+'  margin-left:-2px;' + LineEnding +
+'  padding-left: 3px;' + LineEnding +
+'  border-left:4px solid;' + LineEnding +
+'  border-color: #FF0000;' + LineEnding +
+'}' + LineEnding +
+'dl.tag.note {' + LineEnding +
+'  margin-left:-2px;' + LineEnding +
+'  padding-left: 3px;' + LineEnding +
+'  border-left:4px solid;' + LineEnding +
+'  border-color: #D0C000;' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
 '/* Various browsers have various default styles for <h6>,' + LineEnding +
 '   sometimes ugly for our purposes, so it''s best to set things' + LineEnding +
 '   like font-size and font-weight in out pasdoc.css explicitly. */' + LineEnding +


### PR DESCRIPTION
This adds support for @warning and @note tag and I've tested following commands:
```
  @note(Please open your eyes while reading)
  @note(Please check @link(Create) for more details)
  @note(For more infos see @url(https://www.bing.com/))

  @warning(test)
  @warning(hello @italic(world)!)
  @warning(Does this work? - @bold(Yes.))
```

TODO:
- ~An implementation for LaTeX is missing, I've tried several ways but couldn't get a decent solution.~
- ~Does the `pasdoc.css` in source\component also need to be changed? Couldn't find for what it's used.~

This closes feat-req #34 