### PR TITLE
Fix joining of intf & impl descriptions to ignore leading/trailing whitespaces

### DIFF
--- a/source/component/PasDoc_Parser.pas
+++ b/source/component/PasDoc_Parser.pas
@@ -1487,10 +1487,15 @@ begin
     // Also process case when OldValue is fully contained in NewValue.
     // This allows specifying short abstract in intf section and full description
     // in impl section.
+    // At this stage values are raw, that is, could contain multiple whitespaces.
+    // We must exclude whitespaces from check.
     imtJoin:
-      Result :=
-        IfThen((OldValue <> '') and (OldValue <> Copy(NewValue, 1, Length(OldValue))),
-          OldValue + LineEnding) + NewValue;
+      // Note: this could be optimized to not use 2nd Trim or even check in-place without
+      // creation of new string variables.
+      if (Trim(OldValue) <> '') and not AnsiStartsStr(Trim(OldValue), Trim(NewValue)) then
+        Result := OldValue + LineEnding + NewValue
+      else
+        Result := NewValue;
     imtPreferImpl:
       Result := IfThen(NewValue <> '', NewValue, OldValue);
   end;

--- a/tests/testcases/ok_parse_impl.pas
+++ b/tests/testcases/ok_parse_impl.pas
@@ -186,8 +186,10 @@ procedure Bar;
 begin
 end;
 
-// This is Laz
-// And it must not be doubled
+{
+  This is Laz
+  And it must not be doubled
+}
 procedure Laz;
 begin
 end;


### PR DESCRIPTION
Fixes description doubled in this case:
```delphi
// foo
procedure Foo;

...

{
  foo
  This is foo
}
procedure Foo;
```