### PR TITLE
Fixed SkipBOM not being declared

### DIFF
--- a/source/component/PasDoc_Scanner.pas
+++ b/source/component/PasDoc_Scanner.pas
@@ -846,8 +846,8 @@ var
     {$ELSE}
       IncludeStream := TFileStream.Create(Name, fmOpenRead or fmShareDenyWrite);
     {$ENDIF}
-    {$ENDIF}
       SkipBOM(IncludeStream);
+    {$ENDIF}
       OpenNewTokenizer(IncludeStream, Name, ExtractFilePath(Name));
     end;
   end;


### PR DESCRIPTION
Because of [this](https://github.com/pasdoc/pasdoc/commit/383fc0d9aced7369ed7fe55f3ffe5651879ff5ce) commit we get a build error: "SkipBOM is not defined".