### PR TITLE
Add AutoBackComments option to GUI

### DIFF
--- a/source/gui/frmhelpgeneratorunit.lfm
+++ b/source/gui/frmhelpgeneratorunit.lfm
@@ -244,13 +244,27 @@ object frmHelpGenerator: TfrmHelpGenerator
         Left = 8
         Height = 31
         Hint = 'Check this to support Markdown'
-        Top = 367
+        Top = 484
         Width = 185
         HelpType = htKeyword
         HelpKeyword = 'MarkdownOption'
         Caption = 'Support Markdown style'
         OnChange = SomethingChanged
         TabOrder = 10
+      end
+      object CheckAutoBackComments: TCheckBox
+        AnchorSideTop.Control = CheckMarkdown
+        AnchorSideTop.Side = asrBottom
+        Left = 7
+        Height = 24
+        Hint = 'Check this to to automatically assign a // comment to the preceding identifier on the same line, as thought it were a //< comment'
+        Top = 508	
+        Width = 430
+        HelpType = htKeyword
+        HelpKeyword = 'AutoBackComments'
+        Caption = 'Automatically interpret // comments as //< "back comments"'
+        OnChange = SomethingChanged
+        TabOrder = 11
       end
     end
     object pageSourceFiles: TPage

--- a/source/gui/frmhelpgeneratorunit.lfm
+++ b/source/gui/frmhelpgeneratorunit.lfm
@@ -91,7 +91,7 @@ object frmHelpGenerator: TfrmHelpGenerator
         ParentColor = False
       end
       object CheckAutoAbstract: TCheckBox
-        AnchorSideTop.Control = CheckUseTipueSearch
+        AnchorSideTop.Control = CheckStoreRelativePaths
         AnchorSideTop.Side = asrBottom
         Left = 8
         Height = 31
@@ -179,7 +179,7 @@ object frmHelpGenerator: TfrmHelpGenerator
         TabOrder = 5
       end
       object CheckHandleMacros: TCheckBox
-        AnchorSideTop.Control = CheckAutoAbstract
+        AnchorSideTop.Control = CheckUseTipueSearch
         AnchorSideTop.Side = asrBottom
         Left = 8
         Height = 31
@@ -239,7 +239,7 @@ object frmHelpGenerator: TfrmHelpGenerator
         OnChange = SomethingChanged
       end
       object CheckMarkdown: TCheckBox
-        AnchorSideTop.Control = CheckStoreRelativePaths
+        AnchorSideTop.Control = CheckAutoAbstract
         AnchorSideTop.Side = asrBottom
         Left = 8
         Height = 31

--- a/source/gui/frmhelpgeneratorunit.pas
+++ b/source/gui/frmhelpgeneratorunit.pas
@@ -69,6 +69,9 @@ type
     CheckUseTipueSearch: TCheckBox;
     // Click @name to support Markdown in comments.
     CheckMarkdown: TCheckBox;
+    // Click @name to automatically assign a // comment to the
+    // preceding identifier on the same line.
+    CheckAutoBackComments: TCheckBox;
     // @name controls what members (based on visibility)
     // will be included in generated output.
     CheckListVisibleMembers: TCheckListBox;
@@ -534,6 +537,7 @@ begin
   CheckHandleMacros.Checked := true;
   CheckUseTipueSearch.Checked := false;
   CheckMarkdown.Checked := false;
+  CheckAutoBackComments.Checked := false;
   CheckOpenHTML.Checked := true;
 
   for SortIndex := Low(TSortSetting) to High(TSortSetting) do
@@ -965,6 +969,8 @@ begin
     PasDoc1.Generator.AutoLinkExclude.Assign(MemoAutoLinkExclude.Lines);
     PasDoc1.HandleMacros := CheckHandleMacros.Checked;
 
+    PasDoc1.AutoBackComments := CheckAutoBackComments.Checked;
+
     PasDoc1.ProjectName := edProjectName.Text;
     PasDoc1.IntroductionFileName := EditIntroductionFileName.Text;
     PasDoc1.ConclusionFileName := EditConclusionFileName.Text;
@@ -1288,6 +1294,7 @@ begin
     CheckHandleMacros.Checked := Ini.ReadBool('Main', 'HandleMacros', true);
     CheckUseTipueSearch.Checked := Ini.ReadBool('Main', 'UseTipueSearch', false);
     CheckMarkdown.Checked := Ini.ReadBool('Main', 'Markdown', false);
+    CheckAutoBackComments.Checked := Ini.ReadBool('Main', 'AutoBackComments', false);
     CheckOpenHTML.Checked := Ini.ReadBool('Main', 'OpenHTML', true);
     rgLineBreakQuality.ItemIndex := Ini.ReadInteger('Main', 'LineBreakQuality', 0);
     ReadStrings('HyphenatedWords', memoHyphenatedWords.Lines);
@@ -1411,6 +1418,7 @@ begin
     Ini.WriteBool('Main', 'HandleMacros', CheckHandleMacros.Checked);
     Ini.WriteBool('Main', 'UseTipueSearch', CheckUseTipueSearch.Checked);
     Ini.WriteBool('Main', 'Markdown', CheckMarkdown.Checked);
+    Ini.WriteBool('Main', 'AutoBackComments', CheckAutoBackComments.Checked);
     Ini.WriteBool('Main', 'OpenHTML', CheckOpenHTML.Checked);
 
     Ini.WriteInteger('Main', 'LineBreakQuality', rgLineBreakQuality.ItemIndex);


### PR DESCRIPTION
Adds a checkbox to the GUI Options page to support the --auto-back-comments option (https://pasdoc.github.io/AutoBackComments)

Addresses issue #142