### PR TITLE
Suppress @raises warnings if exception class is in external class hierarchy

### DIFF
--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -1276,7 +1276,11 @@ procedure TGenericHTMLDocGenerator.WriteItemLongDescription(
       ParamName := List[i].Name;
 
       if LinkToParamNames then
-       ParamName := SearchLink(ParamName, ItemToSearchFrom, '', true);
+       ParamName := SearchLink(
+        ParamName,
+        ItemToSearchFrom,
+        '',
+        lnfWarnIfNotInternal);
 
       WriteParameter(ParamName, List[i].Value);
     end;
@@ -1297,7 +1301,7 @@ procedure TGenericHTMLDocGenerator.WriteItemLongDescription(
     for i := 0 to SeeAlso.Count - 1 do
     begin
       SeeAlsoLink := SearchLink(SeeAlso[i].Name, AItem,
-        SeeAlso[i].Value, true, SeeAlsoItem);
+        SeeAlso[i].Value, lnfWarn, SeeAlsoItem);
       WriteDirect('  <dt>');
       if SeeAlsoItem <> nil then
         WriteDirect(SeeAlsoLink) else
@@ -1337,7 +1341,12 @@ procedure TGenericHTMLDocGenerator.WriteItemLongDescription(
         AttributesLink := name;
         AttributesItem := nil;
       end else
-        AttributesLink := SearchLink(name, AItem, name, true, AttributesItem);
+        AttributesLink := SearchLink(
+          name,
+          AItem,
+          name,
+          lnfWarnIfNotInternal,
+          AttributesItem);
       WriteDirect(AttributesLink);
 
       WriteConverted(value);

--- a/source/component/PasDoc_GenLatex.pas
+++ b/source/component/PasDoc_GenLatex.pas
@@ -1043,7 +1043,11 @@ procedure TTexDocGenerator.WriteItemLongDescription(const AItem: TPasItem;
       ParamName := List[i].Name;
 
       if LinkToParamNames then
-       ParamName := SearchLink(ParamName, ItemToSearchFrom, '', true);
+       ParamName := SearchLink(
+        ParamName,
+        ItemToSearchFrom,
+        '',
+        lnfWarnIfNotInternal);
 
       WriteParameter(ParamName, List[i].Value);
     end;
@@ -1068,7 +1072,7 @@ procedure TTexDocGenerator.WriteItemLongDescription(const AItem: TPasItem;
     for i := 0 to SeeAlso.Count - 1 do
     begin
       SeeAlsoLink := SearchLink(SeeAlso[i].Name, AItem,
-        SeeAlso[i].Value, true, SeeAlsoItem);
+        SeeAlso[i].Value, lnfWarn, SeeAlsoItem);
       WriteDirect('\item[');
       if SeeAlsoItem <> nil then
         WriteDirect(SeeAlsoLink) else


### PR DESCRIPTION
Resolves #68 in the way suggested by @michaliskambi.

Parsing a `@raises` tag now only raises a warning if the exception class cannot be found in the project or in the external class hierarchy. Note that warnings are still emitted for `@link` and `@seeAlso` tags that reference external class hierarchy symbols.