### PR TITLE
Check number of parameters passed to "file_to_pascal_*" programs

### DIFF
--- a/source/tools/file_to_pascal_data.dpr
+++ b/source/tools/file_to_pascal_data.dpr
@@ -46,6 +46,12 @@ var
   B: Byte;
   i: Integer;
 begin
+  if ParamCount() <> 2 then
+  begin
+    Writeln(StdErr, 'file_to_pascal_data: Usage: file_to_pascal_data INPUT_FILE OUTPUT_FILE');
+    Writeln(StdErr, 'file_to_pascal_data: Invalid number of arguments: expected 2, got ', ParamCount());
+    Halt(1)
+  end;
   SrcFileName := ParamStr(1);
   DestFileName := ParamStr(2);
 

--- a/source/tools/file_to_pascal_string.dpr
+++ b/source/tools/file_to_pascal_string.dpr
@@ -54,6 +54,12 @@ var
   SrcFileName, DestFileName, S, Next: string;
   LenProcessed, LenNext: Cardinal;
 begin
+  if ParamCount() <> 2 then
+  begin
+    Writeln(StdErr, 'file_to_pascal_string: Usage: file_to_pascal_string INPUT_FILE OUTPUT_FILE');
+    Writeln(StdErr, 'file_to_pascal_string: Invalid number of arguments: expected 2, got ', ParamCount());
+    Halt(1)
+  end;
   SrcFileName := ParamStr(1);
   DestFileName := ParamStr(2);
 


### PR DESCRIPTION
This patch adds a check to `file_to_pascal_data` and `file_to_pascal_string` programs that verifies whether the appropriate number of parameters has been passed.