### PR TITLE
Manually concatenate parameter types in routine signatures

### DIFF
--- a/source/component/PasDoc_Items.pas
+++ b/source/component/PasDoc_Items.pas
@@ -2844,12 +2844,21 @@ begin
 end;
 
 function TPasRoutine.Signature: string;
-begin
-  ParamTypes.QuoteChar := #0;
-  ParamTypes.Delimiter := ',';
 
+  function GetParamTypesStr: string;
+  var
+    ParamType: string;
+  begin
+    Result := '';
+    for ParamType in ParamTypes do
+      Result := SAppendPart(Result, ',', SRemoveChars(ParamType, [' ']));
+  end;
+
+begin
   if ParamTypes.Count > 0 then
-    Result := Name + '(' + SRemoveChars(ParamTypes.DelimitedText, [' ']) + ')'
+    { Note: We're not using TStringList.DelimitedText because of a bug in FPC 3.2.0 affecting quote chars.
+            See https://gitlab.com/freepascal.org/fpc/source/-/issues/37605 }
+    Result := Format('%s(%s)', [Name, GetParamTypesStr])
   else
     Result := Name;
 end;


### PR DESCRIPTION
This PR fixes an issue where routine signatures are not properly generated when compiled with FPC 3.2.0. Instead of using `TStringList.DelimitedText` to concatenate parameter types together for the signature, the string is now manually built.

I ran the tests locally with FPC 3.2.0 and immediately noticed the problem when viewing the diffs in VSCode, which shows invisible characters:

![Screenshot 2023-03-28 160111](https://user-images.githubusercontent.com/28214458/228137898-e14156f6-3be7-49e4-806a-2ac436b823b9.png)

This is due to [a known issue in FPC 3.2.0](https://gitlab.com/freepascal.org/fpc/source/-/issues/37605) where setting `TStringList.QuoteChar` to the null byte does not disable the use of a quote char as expected, but continues to quote with the null byte as the quote char. This was fixed in FPC 3.2.2.