### PR TITLE
Fix incorrect signatures for routines with boolean default parameters

### DIFF
--- a/source/component/PasDoc_Parser.pas
+++ b/source/component/PasDoc_Parser.pas
@@ -918,6 +918,7 @@ procedure TParser.ParseRoutine(out M: TPasRoutine;
     ParamsInGroup: Integer;
     TypeNamePartStarted: Boolean;
     TypeNamePartEnded: Boolean;
+    ParamEnded: Boolean;
     I: Integer;
     TypeName: String;
   begin
@@ -925,6 +926,7 @@ procedure TParser.ParseRoutine(out M: TPasRoutine;
     ParamsInGroup := 0;
     TypeNamePartStarted := False;
     TypeNamePartEnded := False;
+    ParamEnded := False;
     TypeName := '';
     repeat
       T := Scanner.GetToken;
@@ -957,10 +959,10 @@ procedure TParser.ParseRoutine(out M: TPasRoutine;
           end
           else if T.IsSymbol(SYM_SEMICOLON) or T.IsSymbol(SYM_LEFT_PARENTHESIS)
             or T.IsSymbol(SYM_RIGHT_PARENTHESIS) then
-            TypeNamePartEnded := True;
+            ParamEnded := True;
         end;
 
-        if TypeNamePartEnded then
+        if ParamEnded then
         begin
           if TypeName = '' then TypeName := 'const';
 
@@ -970,6 +972,7 @@ procedure TParser.ParseRoutine(out M: TPasRoutine;
           TypeName := '';
           TypeNamePartStarted := False;
           TypeNamePartEnded := False;
+          ParamEnded := False;
           ParamsInGroup := 0;
         end;
 

--- a/tests/testcases/ok_parameter_default_values.pas
+++ b/tests/testcases/ok_parameter_default_values.pas
@@ -4,6 +4,7 @@ interface
 
 procedure Foo(A: Integer; B: Integer = 3; C: Integer = 5);
 procedure Bar(A, B: Integer; C: Integer = 3; D: string = '');
+function Baz(A: Boolean = True): string;
 
 implementation
 

--- a/tests/testcases_output/html/ok_parameter_default_values/AllFunctions.html
+++ b/tests/testcases_output/html/ok_parameter_default_values/AllFunctions.html
@@ -22,6 +22,11 @@
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 <tr class="list2">
+<td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Baz-Boolean-">Baz</a></td>
+<td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
+</tr>
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Foo-Integer-Integer-Integer-">Foo</a></td>
 <td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>

--- a/tests/testcases_output/html/ok_parameter_default_values/AllIdentifiers.html
+++ b/tests/testcases_output/html/ok_parameter_default_values/AllIdentifiers.html
@@ -22,6 +22,11 @@
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 <tr class="list2">
+<td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Baz-Boolean-">Baz</a></td>
+<td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
+</tr>
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Foo-Integer-Integer-Integer-">Foo</a></td>
 <td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>

--- a/tests/testcases_output/html/ok_parameter_default_values/ok_parameter_default_values.html
+++ b/tests/testcases_output/html/ok_parameter_default_values/ok_parameter_default_values.html
@@ -22,6 +22,9 @@
 <tr class="list2">
 <td class="itemcode"><code>procedure <strong><a href="ok_parameter_default_values.html#Bar-Integer-Integer-Integer-string-">Bar</a></strong>(A, B: Integer; C: Integer = 3; D: string = '');</code></td>
 </tr>
+<tr class="list">
+<td class="itemcode"><code>function <strong><a href="ok_parameter_default_values.html#Baz-Boolean-">Baz</a></strong>(A: Boolean = True): string;</code></td>
+</tr>
 </table>
 <h2 class="description">Description</h2>
 <h3 class="detail">Functions and Procedures</h3>
@@ -35,6 +38,13 @@
 <table class="detail wide_list">
 <tr class="list">
 <td class="itemcode"><span id="Bar-Integer-Integer-Integer-string-"></span><code>procedure <strong>Bar</strong>(A, B: Integer; C: Integer = 3; D: string = '');</code></td>
+</tr>
+<tr><td colspan="1">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+<table class="detail wide_list">
+<tr class="list">
+<td class="itemcode"><span id="Baz-Boolean-"></span><code>function <strong>Baz</strong>(A: Boolean = True): string;</code></td>
 </tr>
 <tr><td colspan="1">
 <p class="nodescription">This item has no description.</p></td></tr>

--- a/tests/testcases_output/htmlhelp/ok_parameter_default_values/AllFunctions.html
+++ b/tests/testcases_output/htmlhelp/ok_parameter_default_values/AllFunctions.html
@@ -20,6 +20,11 @@
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 <tr class="list2">
+<td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Baz-Boolean-">Baz</a></td>
+<td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
+</tr>
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Foo-Integer-Integer-Integer-">Foo</a></td>
 <td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>

--- a/tests/testcases_output/htmlhelp/ok_parameter_default_values/AllIdentifiers.html
+++ b/tests/testcases_output/htmlhelp/ok_parameter_default_values/AllIdentifiers.html
@@ -20,6 +20,11 @@
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 <tr class="list2">
+<td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Baz-Boolean-">Baz</a></td>
+<td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
+</tr>
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_parameter_default_values.html#Foo-Integer-Integer-Integer-">Foo</a></td>
 <td class="itemunit"><a class="bold" href="ok_parameter_default_values.html">ok_parameter_default_values</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>

--- a/tests/testcases_output/htmlhelp/ok_parameter_default_values/docs.hhc
+++ b/tests/testcases_output/htmlhelp/ok_parameter_default_values/docs.hhc
@@ -32,6 +32,10 @@
 <param name="Name" value="Bar">
 <param name="Local" value="ok_parameter_default_values.html#Bar">
 </object>
+<li><object type="text/sitemap">
+<param name="Name" value="Baz">
+<param name="Local" value="ok_parameter_default_values.html#Baz">
+</object>
 </ul>
 </ul>
 </ul>

--- a/tests/testcases_output/htmlhelp/ok_parameter_default_values/docs.hhk
+++ b/tests/testcases_output/htmlhelp/ok_parameter_default_values/docs.hhk
@@ -8,6 +8,10 @@
 <param name="Local" value="ok_parameter_default_values.html#Bar-Integer-Integer-Integer-string-">
 </object>
 <li><object type="text/sitemap">
+<param name="Name" value="Baz">
+<param name="Local" value="ok_parameter_default_values.html#Baz-Boolean-">
+</object>
+<li><object type="text/sitemap">
 <param name="Name" value="Foo">
 <param name="Local" value="ok_parameter_default_values.html#Foo-Integer-Integer-Integer-">
 </object>

--- a/tests/testcases_output/htmlhelp/ok_parameter_default_values/ok_parameter_default_values.html
+++ b/tests/testcases_output/htmlhelp/ok_parameter_default_values/ok_parameter_default_values.html
@@ -20,6 +20,9 @@
 <tr class="list2">
 <td class="itemcode"><code>procedure <strong><a href="ok_parameter_default_values.html#Bar-Integer-Integer-Integer-string-">Bar</a></strong>(A, B: Integer; C: Integer = 3; D: string = '');</code></td>
 </tr>
+<tr class="list">
+<td class="itemcode"><code>function <strong><a href="ok_parameter_default_values.html#Baz-Boolean-">Baz</a></strong>(A: Boolean = True): string;</code></td>
+</tr>
 </table>
 <h2 class="description">Description</h2>
 <h3 class="detail">Functions and Procedures</h3>
@@ -33,6 +36,13 @@
 <table class="detail wide_list">
 <tr class="list">
 <td class="itemcode"><span id="Bar-Integer-Integer-Integer-string-"></span><code>procedure <strong>Bar</strong>(A, B: Integer; C: Integer = 3; D: string = '');</code></td>
+</tr>
+<tr><td colspan="1">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+<table class="detail wide_list">
+<tr class="list">
+<td class="itemcode"><span id="Baz-Boolean-"></span><code>function <strong>Baz</strong>(A: Boolean = True): string;</code></td>
 </tr>
 <tr><td colspan="1">
 <p class="nodescription">This item has no description.</p></td></tr>

--- a/tests/testcases_output/latex/ok_parameter_default_values/docs.tex
+++ b/tests/testcases_output/latex/ok_parameter_default_values/docs.tex
@@ -87,6 +87,7 @@
 \begin{description}
 \item[\texttt{Foo}]
 \item[\texttt{Bar}]
+\item[\texttt{Baz}]
 \end{description}
 \section{Functions and Procedures}
 \ifpdf
@@ -141,6 +142,35 @@ procedure Foo(A: Integer; B: Integer = 3; C: Integer = 5);\end{ttfamily}
 \fi
 \begin{ttfamily}
 procedure Bar(A, B: Integer; C: Integer = 3; D: string = '');\end{ttfamily}
+
+\ifpdf
+\end{flushleft}
+\fi
+
+\end{list}
+\ifpdf
+\subsection*{\large{\textbf{Baz}}\normalsize\hspace{1ex}\hrulefill}
+\else
+\subsection*{Baz}
+\fi
+\label{ok_parameter_default_values-Baz}
+\index{Baz}
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\item[\textbf{Declaration}\hfill]
+\ifpdf
+\begin{flushleft}
+\fi
+\begin{ttfamily}
+function Baz(A: Boolean = True): string;\end{ttfamily}
 
 \ifpdf
 \end{flushleft}

--- a/tests/testcases_output/latex2rtf/ok_parameter_default_values/docs.tex
+++ b/tests/testcases_output/latex2rtf/ok_parameter_default_values/docs.tex
@@ -63,6 +63,7 @@
 \begin{description}
 \item[\texttt{Foo}]
 \item[\texttt{Bar}]
+\item[\texttt{Baz}]
 \end{description}
 \section{Functions and Procedures}
 \subsection*{Foo}
@@ -99,6 +100,25 @@ procedure Foo(A: Integer; B: Integer = 3; C: Integer = 5);\end{ttfamily}
 \item[\textbf{Declaration}\hfill]
 \begin{ttfamily}
 procedure Bar(A, B: Integer; C: Integer = 3; D: string = '');\end{ttfamily}
+
+
+\end{flushleft}
+\end{list}
+\subsection*{Baz}
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\begin{flushleft}
+\item[\textbf{Declaration}\hfill]
+\begin{ttfamily}
+function Baz(A: Boolean = True): string;\end{ttfamily}
 
 
 \end{flushleft}

--- a/tests/testcases_output/php/ok_parameter_default_values/docs.php
+++ b/tests/testcases_output/php/ok_parameter_default_values/docs.php
@@ -4,4 +4,5 @@ $pasdoc = array(
   'ok_parameter_default_values' => array('html_filename' => 'ok_parameter_default_values.html', 'type' => 'unit'),
   'Foo' => array('html_filename' => 'ok_parameter_default_values.html#Foo-Integer-Integer-Integer-', 'type' => 'procedure'),
   'Bar' => array('html_filename' => 'ok_parameter_default_values.html#Bar-Integer-Integer-Integer-string-', 'type' => 'procedure'),
+  'Baz' => array('html_filename' => 'ok_parameter_default_values.html#Baz-Boolean-', 'type' => 'function'),
 );

--- a/tests/testcases_output/simplexml/ok_parameter_default_values/ok_parameter_default_values.xml
+++ b/tests/testcases_output/simplexml/ok_parameter_default_values/ok_parameter_default_values.xml
@@ -3,4 +3,6 @@
   </routine>
   <routine name="Bar" type="procedure" declaration="procedure Bar(A, B: Integer; C: Integer = 3; D: string = '');" visibility="published">
   </routine>
+  <routine name="Baz" type="function" declaration="function Baz(A: Boolean = True): string;" visibility="published">
+  </routine>
 </unit>


### PR DESCRIPTION
#164 introduced support for default values when parsing type parameters. Unfortunately, it turns out that my solution did
not handle boolean default values, with `procedure Proc(A: Boolean = True)` having a generated HTML id of
`Proc-Boolean-const-` instead of the correct `Proc-Boolean-`.

This PR fixes the parameter parser to wait for a semicolon before parsing a new set of parameters, resolving this issue.
I've also added a new routine to the `ok_parameter_default_values` test to cover this case.