### PR TITLE
Handle type helpers

### DIFF
--- a/source/component/PasDoc_Gen.pas
+++ b/source/component/PasDoc_Gen.pas
@@ -2488,6 +2488,7 @@ begin
     CIO_PACKEDOBJECT: Result := FLanguage.Translation[trPacked] + ' ' + FLanguage.Translation[trObject];
     CIO_RECORD: Result := FLanguage.Translation[trRecord];
     CIO_PACKEDRECORD: Result := FLanguage.Translation[trPacked] + ' ' + FLanguage.Translation[trRecord];
+    CIO_TYPE: Result := FLanguage.Translation[trType];
   else
     Result := '';
   end;

--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -597,7 +597,8 @@ const
     'object',
     'packed object',
     'record',
-    'packed record');
+    'packed record',
+    'type');
 
   procedure WriteMethodsSummary;
   begin

--- a/source/component/PasDoc_Items.pas
+++ b/source/component/PasDoc_Items.pas
@@ -755,7 +755,9 @@ type
     CIO_DISPINTERFACE, CIO_INTERFACE,
     CIO_OBJECT, CIO_PACKEDOBJECT,
     CIO_RECORD, CIO_PACKEDRECORD,
-    CIO_TYPE {helper only});
+    { CIO_TYPE is used only when CIO is a type helper,
+      designed by CIO.ClassDirective = CT_HELPER. }
+    CIO_TYPE);
 
   TClassDirective = (CT_NONE, CT_ABSTRACT, CT_SEALED, CT_HELPER);
 

--- a/source/component/PasDoc_Items.pas
+++ b/source/component/PasDoc_Items.pas
@@ -754,7 +754,8 @@ type
   TCIOType = (CIO_CLASS, CIO_PACKEDCLASS,
     CIO_DISPINTERFACE, CIO_INTERFACE,
     CIO_OBJECT, CIO_PACKEDOBJECT,
-    CIO_RECORD, CIO_PACKEDRECORD );
+    CIO_RECORD, CIO_PACKEDRECORD,
+    CIO_TYPE {helper only});
 
   TClassDirective = (CT_NONE, CT_ABSTRACT, CT_SEALED, CT_HELPER);
 
@@ -3058,7 +3059,8 @@ const
     'object',
     'packed object',
     'record',
-    'packed record'
+    'packed record',
+    'type' {helper only}
   );
 begin
   Result := Names[CioType];

--- a/source/component/PasDoc_Parser.pas
+++ b/source/component/PasDoc_Parser.pas
@@ -2360,15 +2360,18 @@ begin
             Exit;
           end;
         KEY_TYPE: begin
-            t2 := GetNextToken(LTemp);
+            t2 := PeekNextToken(LTemp);
             IsTypeHelper := (t2.MyType = TOK_IDENTIFIER) and (t2.Info.StandardDirective = SD_HELPER);
-            Scanner.UnGetToken(t2);
             if IsTypeHelper then
             begin
               ParseCIO(U, TypeName, TypeNameWithGeneric, CIO_TYPE,
                 RawDescriptionInfo, False);
               FreeAndNil(t);
               exit;
+            end else
+            begin
+              LCollected := LCollected + LTemp;
+              FreeAndNil(t);
             end;
           end;
         KEY_PACKED: begin
@@ -2929,6 +2932,7 @@ begin
                   if Assigned(Item) then
                     Item.FullDeclaration := Item.FullDeclaration + t.Data + WhitespaceCollectorToAdd;
                   FreeAndNil(t);
+                  WhitespaceCollectorToAdd := '';
                   t := GetNextTokenNotAttribute(Item);
                   if Assigned(Item) then
                   begin

--- a/source/component/PasDoc_Parser.pas
+++ b/source/component/PasDoc_Parser.pas
@@ -2285,7 +2285,8 @@ var
   LCollected, LTemp, TypeNameWithGeneric: string;
   RoutineType: TPasRoutine;
   EnumType: TPasEnum;
-  T: TToken;
+  T, T2: TToken;
+  IsTypeHelper: boolean;
 begin
   { Read the type name, preceded by optional "generic" directive.
     Calculate TypeName, IsGeneric, TypeNameWithGeneric.
@@ -2357,6 +2358,18 @@ begin
               RawDescriptionInfo, False);
             FreeAndNil(t);
             Exit;
+          end;
+        KEY_TYPE: begin
+            t2 := GetNextToken(LTemp);
+            IsTypeHelper := (t2.MyType = TOK_IDENTIFIER) and (t2.Info.StandardDirective = SD_HELPER);
+            Scanner.UnGetToken(t2);
+            if IsTypeHelper then
+            begin
+              ParseCIO(U, TypeName, TypeNameWithGeneric, CIO_TYPE,
+                RawDescriptionInfo, False);
+              FreeAndNil(t);
+              exit;
+            end;
           end;
         KEY_PACKED: begin
             FreeAndNil(t);
@@ -3667,7 +3680,7 @@ begin
         FreeAndNil(t);
         t := GetNextToken;
       end
-      else if (CIOType in [ CIO_CLASS, CIO_RECORD ]) and
+      else if (CIOType in [ CIO_CLASS, CIO_RECORD, CIO_TYPE ]) and
         (t.MyType = TOK_IDENTIFIER) and
         (t.Info.StandardDirective = SD_HELPER) then
       begin
@@ -3815,7 +3828,7 @@ begin
         end;
       end;
 
-      if (CIOType in [ CIO_CLASS, CIO_RECORD ]) and
+      if (CIOType in [ CIO_CLASS, CIO_RECORD, CIO_TYPE ]) and
           (ACio.ClassDirective = CT_HELPER) then
       begin
         t := PeekNextToken;

--- a/source/component/PasDoc_Parser.pas
+++ b/source/component/PasDoc_Parser.pas
@@ -2286,7 +2286,7 @@ var
   RoutineType: TPasRoutine;
   EnumType: TPasEnum;
   T, T2: TToken;
-  IsTypeHelper: boolean;
+  IsStrongAlias: boolean;
 begin
   { Read the type name, preceded by optional "generic" directive.
     Calculate TypeName, IsGeneric, TypeNameWithGeneric.
@@ -2360,9 +2360,8 @@ begin
             Exit;
           end;
         KEY_TYPE: begin
-            t2 := PeekNextToken(LTemp);
-            IsTypeHelper := (t2.MyType = TOK_IDENTIFIER) and (t2.Info.StandardDirective = SD_HELPER);
-            if IsTypeHelper then
+            T2 := PeekNextToken(LTemp);
+            if T2.IsStandardDirective(SD_HELPER) then
             begin
               ParseCIO(U, TypeName, TypeNameWithGeneric, CIO_TYPE,
                 RawDescriptionInfo, False);

--- a/source/component/PasDoc_Scanner.pas
+++ b/source/component/PasDoc_Scanner.pas
@@ -75,8 +75,6 @@ type
   { This class scans one unit using one or more @link(TTokenizer) objects
     to scan the unit and all nested include files. }
 
-  { TScanner }
-
   TScanner = class(TObject)
   private
     FCurrentTokenizer: Integer;

--- a/source/component/PasDoc_Scanner.pas
+++ b/source/component/PasDoc_Scanner.pas
@@ -49,7 +49,8 @@ uses
   PasDoc_Tokenizer,
   PasDoc_StringVector,
   PasDoc_StreamUtils,
-  PasDoc_StringPairVector;
+  PasDoc_StringPairVector,
+  PasDoc_ObjectVector;
 
 const
   { maximum number of streams we can recurse into; first one is the unit
@@ -73,13 +74,16 @@ type
 
   { This class scans one unit using one or more @link(TTokenizer) objects
     to scan the unit and all nested include files. }
+
+  { TScanner }
+
   TScanner = class(TObject)
   private
     FCurrentTokenizer: Integer;
     FDirectiveLevel: Integer;
     FTokenizers: array[0..MAX_TOKENIZERS - 1] of TTokenizer;
     FSwitchOptions: TSwitchOptions;
-    FBufferedToken: TToken;
+    FBufferedTokens: TObjectVector;
 
     { For each symbol:
         Name is the unique Name,
@@ -373,7 +377,7 @@ begin
   FTokenizers[0] := TTokenizer.Create(s, OnMessageEvent, VerbosityLevel,
     AStreamName, AStreamPath);
   FCurrentTokenizer := 0;
-  FBufferedToken := nil;
+  FBufferedTokens := TObjectVector.Create(true);
 
   FIncludeFilePaths := TStringVector.Create;
 end;
@@ -390,7 +394,7 @@ begin
     FTokenizers[i].Free;
   end;
 
-  FBufferedToken.Free;
+  FBufferedTokens.Free;
 
   FIncludeFilePaths.Free;
 
@@ -448,8 +452,14 @@ end;
 { ---------------------------------------------------------------------------- }
 
 procedure TScanner.ConsumeToken;
+var
+  LastToken: TObject;
 begin
-  FBufferedToken := nil;
+  if FBufferedTokens.Count > 0 then
+  Begin
+    LastToken := FBufferedTokens.Last;
+    FBufferedTokens.Extract(LastToken);
+  end;
 end;
 
 { ---------------------------------------------------------------------------- }
@@ -602,11 +612,11 @@ var
   Finished: Boolean;
   DirectiveName, DirectiveParamBlack, DirectiveParamWhite: string;
 begin
-  if Assigned(FBufferedToken) then
+  if FBufferedTokens.Count > 0 then
   begin
     { we have a token buffered, we'll return this one }
-    Result := FBufferedToken;
-    FBufferedToken := nil;
+    Result := FBufferedTokens.Last as TToken;
+    FBufferedTokens.Extract(Result);
     Exit;
   end;
 
@@ -897,8 +907,8 @@ end;
 
 function TScanner.PeekToken: TToken;
 begin
-  FBufferedToken := GetToken;
-  Result := FBufferedToken;
+  Result := GetToken;
+  FBufferedTokens.Add(Result);
 end;
 
 { ---------------------------------------------------------------------------- }
@@ -978,11 +988,7 @@ end;
 
 procedure TScanner.UnGetToken(var t: TToken);
 begin
-  if Assigned(FBufferedToken) then
-    DoError('%s: Cannot UnGet more than one token in TScanner.',
-      [GetStreamInfo]);
-
-  FBufferedToken := t;
+  FBufferedTokens.Add(t);
   t := nil;
 end;
 


### PR DESCRIPTION
Hi!

This is a new attempt at implementing type helpers. The idea is that when encountering the `type` keyword, a forward check for the next token to be `helper` let us know if this is a type helper and not a type redefinition.

I was not sure how the unit tests work. Though I tried it on BGRABitmapTypes and it was successful with the code mentioned in issue #113.

Regards