### PR TITLE
Handle type alias (strong and weak)

### DIFF
--- a/source/component/PasDoc_Items.pas
+++ b/source/component/PasDoc_Items.pas
@@ -633,6 +633,18 @@ type
   TPasType = class(TPasItem)
   end;
 
+  { @abstract(Alias type) }
+  TPasAliasType = class(TPasType)
+    FIsStrongAlias: boolean;
+    FAliasName: string;
+  public
+    { Whether it is a strong alias, defined with the "type" keyword, for example:
+      StrongAlias = type AliasedType }
+    property IsStrongAlias: boolean read FIsStrongAlias write FIsStrongAlias;
+    { Name of the type it refers to }
+    property AliasName: string read FAliasName write FAliasName;
+  end;
+
   { @abstract(Enumerated type.) }
   TPasEnum = class(TPasType)
   protected

--- a/source/component/PasDoc_Types.pas
+++ b/source/component/PasDoc_Types.pas
@@ -97,6 +97,9 @@ const
   and splitted name is returned as NameParts. }
 function SplitNameParts(S: string; out NameParts: TNameParts): Boolean;
 
+{ Checks that the string is a valid multipart identifier }
+function IsValidMultipartName(S: string): boolean;
+
 { Simply returns an array with Length = 1 and one item = S. }
 function OneNamePart(const S: string): TNameParts;
 
@@ -210,6 +213,13 @@ begin
 
   NameParts := SplitString(s, '.');
   Result := True;
+end;
+
+function IsValidMultipartName(S: string): boolean;
+var
+  DummyParts: TNameParts;
+begin
+  result := SplitNameParts(S, DummyParts);
 end;
 
 function OneNamePart(const S: string): TNameParts;


### PR DESCRIPTION
Handle type alias and retrieve definition of aliased type in the generated documentation.

Sample unit:
```pascal
unit TestAlias;

interface 

type
  { My original type description }
  TOriginalType = record x,y: integer end;
  TWeakAliasType = TOriginalType;
  TStrongAliasType = type TOriginalType;

implementation
 
end. 
```

I've introduced the new type `TPasAliasType`. It derives from `TPasType` and is a type alias.

I've extracted the `WriteDescription` procedure in order to call it recursively from `WriteNoDescription`.

Parsing is done differently for strong and weak alias. For strong alias, we know for sure we except an alias after the `type` keyword. For weak alias, this is determined after reading the description.

Here is a screenshot of generated documentation:
<img width="601" alt="type_alias_doc" src="https://github.com/pasdoc/pasdoc/assets/9092455/d426e4dd-aafe-4c7b-b8a3-80357e38ad85">
