### PR TITLE
Restore Delphi compatibility

### DIFF
--- a/source/component/PasDoc_Parser.pas
+++ b/source/component/PasDoc_Parser.pas
@@ -2518,7 +2518,7 @@ const
   MacroSeparator = ':=';
 var
   D: string;
-  IndexMacroSeparator: SizeInt;
+  IndexMacroSeparator: NativeInt;
 begin
   for D in Directives do
   begin


### PR DESCRIPTION
A recent change introduced a usage of the FPC-only `SizeInt` type, breaking compatibility with Delphi. 

This PR replaces that usage with the Delphi-compatible `NativeInt` type instead - I've confirmed that with this change, PasDoc now compiles with FPC and Delphi.