### PR TITLE
Try using `Attribute` suffix when attribute search fails

### DIFF
--- a/source/component/PasDoc_Gen.pas
+++ b/source/component/PasDoc_Gen.pas
@@ -2683,23 +2683,23 @@ begin
         end;
       else Assert(false, 'LinkLook = ??');
     end;
-  end else
-  if (WarningIfLinkNotFound = lnfWarnIfNotInternal) and
-     (FExternalClassHierarchy.IndexOfName(S) <> -1) then begin
-    DoMessage(
-      6,
-      pmtInformation,
-      'Link "%s" resolved as reference to external class hierarchy (from description of "%s")',
-      [S, Item.QualifiedName]);
-    Result := CodeString(ConvertString(S));
   end
-  else if (WarningIfLinkNotFound <> lnfIgnore) then
-  begin
-    DoMessage(1, pmtWarning, 'Could not resolve link "%s" (from description of "%s")',
-      [S, Item.QualifiedName]);
+  else begin
+    if (WarningIfLinkNotFound = lnfWarnIfNotInternal)
+      and (FExternalClassHierarchy.IndexOfName(S) <> -1) then begin
+      DoMessage(
+        6,
+        pmtInformation,
+        'Link "%s" resolved as reference to external class hierarchy (from description of "%s")',
+        [S, Item.QualifiedName]);
+    end
+    else if (WarningIfLinkNotFound <> lnfIgnore) then begin
+      DoMessage(1, pmtWarning, 'Could not resolve link "%s" (from description of "%s")',
+        [S, Item.QualifiedName]);
+    end;
+
     Result := CodeString(ConvertString(S));
-  end else
-    Result := '';
+  end;
 end;
 
 function TDocGenerator.SearchLink(s: string; const Item: TBaseItem;

--- a/source/component/PasDoc_Gen.pas
+++ b/source/component/PasDoc_Gen.pas
@@ -2684,16 +2684,19 @@ begin
       else Assert(false, 'LinkLook = ??');
     end;
   end
-  else begin
-    if (WarningIfLinkNotFound = lnfWarnIfNotInternal)
-      and (FExternalClassHierarchy.IndexOfName(S) <> -1) then begin
+  else
+  begin
+    if (WarningIfLinkNotFound = lnfWarnIfNotInternal) and
+       (FExternalClassHierarchy.IndexOfName(S) <> -1) then
+    begin
       DoMessage(
         6,
         pmtInformation,
         'Link "%s" resolved as reference to external class hierarchy (from description of "%s")',
         [S, Item.QualifiedName]);
-    end
-    else if (WarningIfLinkNotFound <> lnfIgnore) then begin
+    end else
+    if (WarningIfLinkNotFound <> lnfIgnore) then
+    begin
       DoMessage(1, pmtWarning, 'Could not resolve link "%s" (from description of "%s")',
         [S, Item.QualifiedName]);
     end;

--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -1382,7 +1382,8 @@ procedure TGenericHTMLDocGenerator.WriteItemLongDescription(
           lnfIgnore,
           AttributesItem);
 
-        if not Assigned(AttributesItem) then begin
+        if not Assigned(AttributesItem) then
+        begin
           ExtendedAttrLink := SearchLink(
             name + 'Attribute',
             AItem,

--- a/source/component/PasDoc_GenHtml.pas
+++ b/source/component/PasDoc_GenHtml.pas
@@ -1354,6 +1354,7 @@ procedure TGenericHTMLDocGenerator.WriteItemLongDescription(
     name, value: string;
     AttributesItem: TBaseItem;
     AttributesLink: string;
+    ExtendedAttrLink: string;
   begin
     if ObjectVectorIsNilOrEmpty(Attributes) then
       Exit;
@@ -1372,13 +1373,27 @@ procedure TGenericHTMLDocGenerator.WriteItemLongDescription(
       begin
         AttributesLink := name;
         AttributesItem := nil;
-      end else
+      end
+      else begin
         AttributesLink := SearchLink(
           name,
           AItem,
           name,
-          lnfWarnIfNotInternal,
+          lnfIgnore,
           AttributesItem);
+
+        if not Assigned(AttributesItem) then begin
+          ExtendedAttrLink := SearchLink(
+            name + 'Attribute',
+            AItem,
+            name,
+            lnfIgnore,
+            AttributesItem);
+
+          if Assigned(AttributesItem) then
+            AttributesLink := ExtendedAttrLink;
+        end;
+      end;
       WriteDirect(AttributesLink);
 
       WriteConverted(value);

--- a/tests/testcases/ok_attributes.pas
+++ b/tests/testcases/ok_attributes.pas
@@ -5,6 +5,21 @@ interface
 // Delphi attributes test from http://www.malcolmgroves.com/blog/?p=530
 
 type
+  // Attribute class, without Attribute suffix, PasDoc should link to it
+  NonEmptyString = class(TCustomAttribute)
+    constructor Create(const AMessage: String);
+  end;
+
+  // Attribute class, with Attribute suffix, PasDoc should link to it too
+  MinimumIntegerAttribute = class(TCustomAttribute)
+    constructor Create(const MinInt: Integer; const AMessage: String);
+  end;
+
+  // Attribute class, with Attribute suffix, PasDoc should link to it too
+  MaximumIntegerAttribute = class(TCustomAttribute)
+    constructor Create(const MaxInt: Integer; const AMessage: String);
+  end;
+
   TPerson = class
   private
     FName: String;

--- a/tests/testcases_output/html/ok_attributes/AllClasses.html
+++ b/tests/testcases_output/html/ok_attributes/AllClasses.html
@@ -27,19 +27,34 @@
 <td class="itemdesc"><p>Test that GUIDs are handled gracefully</p></td>
 </tr>
 <tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.MaximumIntegerAttribute.html">MaximumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list2">
+<td class="itemname"><a class="bold" href="ok_attributes.MinimumIntegerAttribute.html">MinimumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.NonEmptyString.html">NonEmptyString</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a> Attribute class, without Attribute suffix, PasDoc should link to it</p></td>
+</tr>
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass1.html">TMyClass1</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>Tests from <a href="https://github.com/pasdoc/pasdoc/issues/179">https://github.com/pasdoc/pasdoc/issues/179</a></p></td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass2.html">TMyClass2</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TPerson.html">TPerson</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
-<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a></p></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 </table>
 </div></div></body></html>

--- a/tests/testcases_output/html/ok_attributes/AllIdentifiers.html
+++ b/tests/testcases_output/html/ok_attributes/AllIdentifiers.html
@@ -27,19 +27,34 @@
 <td class="itemdesc"><p>Test that GUIDs are handled gracefully</p></td>
 </tr>
 <tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.MaximumIntegerAttribute.html">MaximumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list2">
+<td class="itemname"><a class="bold" href="ok_attributes.MinimumIntegerAttribute.html">MinimumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.NonEmptyString.html">NonEmptyString</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a> Attribute class, without Attribute suffix, PasDoc should link to it</p></td>
+</tr>
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass1.html">TMyClass1</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>Tests from <a href="https://github.com/pasdoc/pasdoc/issues/179">https://github.com/pasdoc/pasdoc/issues/179</a></p></td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass2.html">TMyClass2</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TPerson.html">TPerson</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
-<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a></p></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 </table>
 </div></div></body></html>

--- a/tests/testcases_output/html/ok_attributes/ClassHierarchy.html
+++ b/tests/testcases_output/html/ok_attributes/ClassHierarchy.html
@@ -14,6 +14,9 @@
 <li><a class="bold" href="ok_attributes.IEnumerator.generic.html">IEnumerator</a><li>IInterface<ul class="hierarchylevel">
 <li><a class="bold" href="ok_attributes.IUIContainer.html">IUIContainer</a></ul>
 </li>
+<li>TCustomAttribute<ul class="hierarchylevel">
+<li><a class="bold" href="ok_attributes.MaximumIntegerAttribute.html">MaximumIntegerAttribute</a><li><a class="bold" href="ok_attributes.MinimumIntegerAttribute.html">MinimumIntegerAttribute</a><li><a class="bold" href="ok_attributes.NonEmptyString.html">NonEmptyString</a></ul>
+</li>
 <li>TObject<ul class="hierarchylevel">
 <li><a class="bold" href="ok_attributes.TMyClass1.html">TMyClass1</a><li><a class="bold" href="ok_attributes.TMyClass2.html">TMyClass2</a><li><a class="bold" href="ok_attributes.TPerson.html">TPerson</a></ul>
 </li>

--- a/tests/testcases_output/html/ok_attributes/PASDOC-OUTPUT
+++ b/tests/testcases_output/html/ok_attributes/PASDOC-OUTPUT
@@ -8,11 +8,4 @@ Info[2]:    Expanding descriptions (pass 1) ...
 Info[2]:    Expanding descriptions (pass 2) ...
 Info[2]:    ... Descriptions expanded
 Info[2]:    Writing Docs for unit "ok_attributes"
-Warning[1]: Could not resolve link "NonEmptyString" (from description of "ok_attributes.TPerson.Name")
-Warning[1]: Could not resolve link "MinimumInteger" (from description of "ok_attributes.TPerson.Age")
-Warning[1]: Could not resolve link "MaximumInteger" (from description of "ok_attributes.TPerson.Age")
-Warning[1]: Could not resolve link "Volatile" (from description of "ok_attributes.TMyClass1")
-Warning[1]: Could not resolve link "Volatile" (from description of "ok_attributes.TMyClass2.FLockCount")
-Warning[1]: Could not resolve link "HPPGEN" (from description of "ok_attributes.IEnumerator.GetCurrent")
-Warning[1]: Could not resolve link "HPPGEN" (from description of "ok_attributes.IEnumerator.Current")
 Info[1]:    Done

--- a/tests/testcases_output/html/ok_attributes/ok_attributes.MaximumIntegerAttribute.html
+++ b/tests/testcases_output/html/ok_attributes/ok_attributes.MaximumIntegerAttribute.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ok_attributes: Class MaximumIntegerAttribute</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<link rel="StyleSheet" type="text/css" href="pasdoc.css">
+</head>
+<body>
+<div class="container"><div class="navigation">
+<ul><li><a href="AllUnits.html">Units</a></li><li><a href="ClassHierarchy.html">Class Hierarchy</a></li><li><a href="AllClasses.html">Classes, Interfaces, Objects and Records</a></li><li><a href="AllTypes.html">Types</a></li><li><a href="AllVariables.html">Variables</a></li><li><a href="AllConstants.html">Constants</a></li><li><a href="AllFunctions.html">Functions and Procedures</a></li><li><a href="AllIdentifiers.html">Identifiers</a></li></ul></div><div class="content">
+<span id="MaximumIntegerAttribute"></span><h1 class="cio">Class MaximumIntegerAttribute</h1>
+<div class="sections">
+<div class="one_section"><a class="section" href="#PasDoc-Description">Description</a></div><div class="one_section"><a class="section" href="#PasDoc-Hierarchy">Hierarchy</a></div><div class="one_section">Fields</div><div class="one_section"><a class="section" href="#PasDoc-Methods">Methods</a></div><div class="one_section">Properties</div></div>
+<span id="PasDoc-Description"></span><h2 class="unit">Unit</h2>
+<p class="unitlink">
+<a href="ok_attributes.html">ok_attributes</a></p>
+<h2 class="declaration">Declaration</h2>
+<p class="declaration">
+<code>type MaximumIntegerAttribute = class(TCustomAttribute)</code></p>
+<h2 class="description">Description</h2>
+<p>
+Attribute class, with Attribute suffix, PasDoc should link to it too</p>
+<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<ul class="hierarchy"><li class="ancestor">TCustomAttribute</li>
+<li class="thisitem">MaximumIntegerAttribute</li></ul><h2 class="overview">Overview</h2>
+<span id="PasDoc-Methods"></span><h3 class="summary">Methods</h3>
+<table class="summary wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><code>constructor <strong><a href="ok_attributes.MaximumIntegerAttribute.html#Create-Integer-String-">Create</a></strong>(const MaxInt: Integer; const AMessage: String);</code></td>
+</tr>
+</table>
+<h2 class="description">Description</h2>
+<h3 class="detail">Methods</h3>
+<table class="detail wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><span id="Create-Integer-String-"></span><code>constructor <strong>Create</strong>(const MaxInt: Integer; const AMessage: String);</code></td>
+</tr>
+<tr><td colspan="2">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+</div></div></body></html>

--- a/tests/testcases_output/html/ok_attributes/ok_attributes.MinimumIntegerAttribute.html
+++ b/tests/testcases_output/html/ok_attributes/ok_attributes.MinimumIntegerAttribute.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ok_attributes: Class MinimumIntegerAttribute</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<link rel="StyleSheet" type="text/css" href="pasdoc.css">
+</head>
+<body>
+<div class="container"><div class="navigation">
+<ul><li><a href="AllUnits.html">Units</a></li><li><a href="ClassHierarchy.html">Class Hierarchy</a></li><li><a href="AllClasses.html">Classes, Interfaces, Objects and Records</a></li><li><a href="AllTypes.html">Types</a></li><li><a href="AllVariables.html">Variables</a></li><li><a href="AllConstants.html">Constants</a></li><li><a href="AllFunctions.html">Functions and Procedures</a></li><li><a href="AllIdentifiers.html">Identifiers</a></li></ul></div><div class="content">
+<span id="MinimumIntegerAttribute"></span><h1 class="cio">Class MinimumIntegerAttribute</h1>
+<div class="sections">
+<div class="one_section"><a class="section" href="#PasDoc-Description">Description</a></div><div class="one_section"><a class="section" href="#PasDoc-Hierarchy">Hierarchy</a></div><div class="one_section">Fields</div><div class="one_section"><a class="section" href="#PasDoc-Methods">Methods</a></div><div class="one_section">Properties</div></div>
+<span id="PasDoc-Description"></span><h2 class="unit">Unit</h2>
+<p class="unitlink">
+<a href="ok_attributes.html">ok_attributes</a></p>
+<h2 class="declaration">Declaration</h2>
+<p class="declaration">
+<code>type MinimumIntegerAttribute = class(TCustomAttribute)</code></p>
+<h2 class="description">Description</h2>
+<p>
+Attribute class, with Attribute suffix, PasDoc should link to it too</p>
+<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<ul class="hierarchy"><li class="ancestor">TCustomAttribute</li>
+<li class="thisitem">MinimumIntegerAttribute</li></ul><h2 class="overview">Overview</h2>
+<span id="PasDoc-Methods"></span><h3 class="summary">Methods</h3>
+<table class="summary wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><code>constructor <strong><a href="ok_attributes.MinimumIntegerAttribute.html#Create-Integer-String-">Create</a></strong>(const MinInt: Integer; const AMessage: String);</code></td>
+</tr>
+</table>
+<h2 class="description">Description</h2>
+<h3 class="detail">Methods</h3>
+<table class="detail wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><span id="Create-Integer-String-"></span><code>constructor <strong>Create</strong>(const MinInt: Integer; const AMessage: String);</code></td>
+</tr>
+<tr><td colspan="2">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+</div></div></body></html>

--- a/tests/testcases_output/html/ok_attributes/ok_attributes.NonEmptyString.html
+++ b/tests/testcases_output/html/ok_attributes/ok_attributes.NonEmptyString.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ok_attributes: Class NonEmptyString</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<link rel="StyleSheet" type="text/css" href="pasdoc.css">
+</head>
+<body>
+<div class="container"><div class="navigation">
+<ul><li><a href="AllUnits.html">Units</a></li><li><a href="ClassHierarchy.html">Class Hierarchy</a></li><li><a href="AllClasses.html">Classes, Interfaces, Objects and Records</a></li><li><a href="AllTypes.html">Types</a></li><li><a href="AllVariables.html">Variables</a></li><li><a href="AllConstants.html">Constants</a></li><li><a href="AllFunctions.html">Functions and Procedures</a></li><li><a href="AllIdentifiers.html">Identifiers</a></li></ul></div><div class="content">
+<span id="NonEmptyString"></span><h1 class="cio">Class NonEmptyString</h1>
+<div class="sections">
+<div class="one_section"><a class="section" href="#PasDoc-Description">Description</a></div><div class="one_section"><a class="section" href="#PasDoc-Hierarchy">Hierarchy</a></div><div class="one_section">Fields</div><div class="one_section"><a class="section" href="#PasDoc-Methods">Methods</a></div><div class="one_section">Properties</div></div>
+<span id="PasDoc-Description"></span><h2 class="unit">Unit</h2>
+<p class="unitlink">
+<a href="ok_attributes.html">ok_attributes</a></p>
+<h2 class="declaration">Declaration</h2>
+<p class="declaration">
+<code>type NonEmptyString = class(TCustomAttribute)</code></p>
+<h2 class="description">Description</h2>
+<p>
+Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a> Attribute class, without Attribute suffix, PasDoc should link to it</p>
+<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<ul class="hierarchy"><li class="ancestor">TCustomAttribute</li>
+<li class="thisitem">NonEmptyString</li></ul><h2 class="overview">Overview</h2>
+<span id="PasDoc-Methods"></span><h3 class="summary">Methods</h3>
+<table class="summary wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><code>constructor <strong><a href="ok_attributes.NonEmptyString.html#Create-String-">Create</a></strong>(const AMessage: String);</code></td>
+</tr>
+</table>
+<h2 class="description">Description</h2>
+<h3 class="detail">Methods</h3>
+<table class="detail wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><span id="Create-String-"></span><code>constructor <strong>Create</strong>(const AMessage: String);</code></td>
+</tr>
+<tr><td colspan="2">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+</div></div></body></html>

--- a/tests/testcases_output/html/ok_attributes/ok_attributes.TPerson.html
+++ b/tests/testcases_output/html/ok_attributes/ok_attributes.TPerson.html
@@ -19,9 +19,7 @@
 <p class="declaration">
 <code>type TPerson = class(TObject)</code></p>
 <h2 class="description">Description</h2>
-<p>
-Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a></p>
-<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<p class="nodescription">This item has no description.</p><span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
 <ul class="hierarchy"><li class="ancestor">TObject</li>
 <li class="thisitem">TPerson</li></ul><h2 class="overview">Overview</h2>
 <span id="PasDoc-Properties"></span><h3 class="summary">Properties</h3>
@@ -45,7 +43,7 @@ Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">h
 <tr><td colspan="2">
 <p class="nodescription">This item has no description.</p><h6 class="description_section">Attributes</h6>
 <dl class="attributes">
-  <dt><code>NonEmptyString</code>('Must provide a Name')</dt>
+  <dt><a class="normal" href="ok_attributes.NonEmptyString.html">NonEmptyString</a>('Must provide a Name')</dt>
   <dd></dd>
 </dl>
 </td></tr>
@@ -58,9 +56,9 @@ Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">h
 <tr><td colspan="2">
 <p class="nodescription">This item has no description.</p><h6 class="description_section">Attributes</h6>
 <dl class="attributes">
-  <dt><code>MinimumInteger</code>(18, 'Must be at least 18 years old')</dt>
+  <dt><a class="normal" href="ok_attributes.MinimumIntegerAttribute.html">MinimumInteger</a>(18, 'Must be at least 18 years old')</dt>
   <dd></dd>
-  <dt><code>MaximumInteger</code>(65, 'Must be no older than 65 years')</dt>
+  <dt><a class="normal" href="ok_attributes.MaximumIntegerAttribute.html">MaximumInteger</a>(65, 'Must be no older than 65 years')</dt>
   <dd></dd>
 </dl>
 </td></tr>

--- a/tests/testcases_output/html/ok_attributes/ok_attributes.html
+++ b/tests/testcases_output/html/ok_attributes/ok_attributes.html
@@ -21,22 +21,34 @@
 <th class="itemdesc">Description</th>
 </tr>
 <tr class="list">
+<td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.NonEmptyString.html"><code>NonEmptyString</code></a></td>
+<td class="itemdesc">&nbsp;</td>
+</tr>
+<tr class="list2">
+<td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.MinimumIntegerAttribute.html"><code>MinimumIntegerAttribute</code></a></td>
+<td class="itemdesc">&nbsp;</td>
+</tr>
+<tr class="list">
+<td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.MaximumIntegerAttribute.html"><code>MaximumIntegerAttribute</code></a></td>
+<td class="itemdesc">&nbsp;</td>
+</tr>
+<tr class="list2">
 <td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.TPerson.html"><code>TPerson</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname">Interface&nbsp;<a class="bold" href="ok_attributes.IUIContainer.html"><code>IUIContainer</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.TMyClass1.html"><code>TMyClass1</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.TMyClass2.html"><code>TMyClass2</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname">Interface&nbsp;<a class="bold" href="ok_attributes.IEnumerator.generic.html"><code>IEnumerator</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>

--- a/tests/testcases_output/htmlhelp/ok_attributes/AllClasses.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/AllClasses.html
@@ -25,19 +25,34 @@
 <td class="itemdesc"><p>Test that GUIDs are handled gracefully</p></td>
 </tr>
 <tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.MaximumIntegerAttribute.html">MaximumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list2">
+<td class="itemname"><a class="bold" href="ok_attributes.MinimumIntegerAttribute.html">MinimumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.NonEmptyString.html">NonEmptyString</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a> Attribute class, without Attribute suffix, PasDoc should link to it</p></td>
+</tr>
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass1.html">TMyClass1</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>Tests from <a href="https://github.com/pasdoc/pasdoc/issues/179">https://github.com/pasdoc/pasdoc/issues/179</a></p></td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass2.html">TMyClass2</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TPerson.html">TPerson</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
-<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a></p></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 </table>
 </body></html>

--- a/tests/testcases_output/htmlhelp/ok_attributes/AllIdentifiers.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/AllIdentifiers.html
@@ -25,19 +25,34 @@
 <td class="itemdesc"><p>Test that GUIDs are handled gracefully</p></td>
 </tr>
 <tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.MaximumIntegerAttribute.html">MaximumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list2">
+<td class="itemname"><a class="bold" href="ok_attributes.MinimumIntegerAttribute.html">MinimumIntegerAttribute</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Attribute class, with Attribute suffix, PasDoc should link to it too</p></td>
+</tr>
+<tr class="list">
+<td class="itemname"><a class="bold" href="ok_attributes.NonEmptyString.html">NonEmptyString</a></td>
+<td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
+<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a> Attribute class, without Attribute suffix, PasDoc should link to it</p></td>
+</tr>
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass1.html">TMyClass1</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>Tests from <a href="https://github.com/pasdoc/pasdoc/issues/179">https://github.com/pasdoc/pasdoc/issues/179</a></p></td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname"><a class="bold" href="ok_attributes.TMyClass2.html">TMyClass2</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
 <td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname"><a class="bold" href="ok_attributes.TPerson.html">TPerson</a></td>
 <td class="itemunit"><a class="bold" href="ok_attributes.html">ok_attributes</a></td>
-<td class="itemdesc"><p>Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a></p></td>
+<td class="itemdesc"><p>&nbsp;</p></td>
 </tr>
 </table>
 </body></html>

--- a/tests/testcases_output/htmlhelp/ok_attributes/ClassHierarchy.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/ClassHierarchy.html
@@ -12,6 +12,9 @@
 <li><a class="bold" href="ok_attributes.IEnumerator.generic.html">IEnumerator</a><li>IInterface<ul class="hierarchylevel">
 <li><a class="bold" href="ok_attributes.IUIContainer.html">IUIContainer</a></ul>
 </li>
+<li>TCustomAttribute<ul class="hierarchylevel">
+<li><a class="bold" href="ok_attributes.MaximumIntegerAttribute.html">MaximumIntegerAttribute</a><li><a class="bold" href="ok_attributes.MinimumIntegerAttribute.html">MinimumIntegerAttribute</a><li><a class="bold" href="ok_attributes.NonEmptyString.html">NonEmptyString</a></ul>
+</li>
 <li>TObject<ul class="hierarchylevel">
 <li><a class="bold" href="ok_attributes.TMyClass1.html">TMyClass1</a><li><a class="bold" href="ok_attributes.TMyClass2.html">TMyClass2</a><li><a class="bold" href="ok_attributes.TPerson.html">TPerson</a></ul>
 </li>

--- a/tests/testcases_output/htmlhelp/ok_attributes/PASDOC-OUTPUT
+++ b/tests/testcases_output/htmlhelp/ok_attributes/PASDOC-OUTPUT
@@ -8,13 +8,6 @@ Info[2]:    Expanding descriptions (pass 1) ...
 Info[2]:    Expanding descriptions (pass 2) ...
 Info[2]:    ... Descriptions expanded
 Info[2]:    Writing Docs for unit "ok_attributes"
-Warning[1]: Could not resolve link "NonEmptyString" (from description of "ok_attributes.TPerson.Name")
-Warning[1]: Could not resolve link "MinimumInteger" (from description of "ok_attributes.TPerson.Age")
-Warning[1]: Could not resolve link "MaximumInteger" (from description of "ok_attributes.TPerson.Age")
-Warning[1]: Could not resolve link "Volatile" (from description of "ok_attributes.TMyClass1")
-Warning[1]: Could not resolve link "Volatile" (from description of "ok_attributes.TMyClass2.FLockCount")
-Warning[1]: Could not resolve link "HPPGEN" (from description of "ok_attributes.IEnumerator.GetCurrent")
-Warning[1]: Could not resolve link "HPPGEN" (from description of "ok_attributes.IEnumerator.Current")
 Info[2]:    Writing HtmlHelp Content file "docs"...
 Info[2]:    Writing HtmlHelp Index file "docs"...
 Info[1]:    Done

--- a/tests/testcases_output/htmlhelp/ok_attributes/docs.hhc
+++ b/tests/testcases_output/htmlhelp/ok_attributes/docs.hhc
@@ -19,6 +19,54 @@
 </object>
 <ul>
 <li><object type="text/sitemap">
+<param name="Name" value="NonEmptyString">
+<param name="Local" value="ok_attributes.NonEmptyString.html">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Methods">
+<param name="Local" value="ok_attributes.NonEmptyString.html#@Methods">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.NonEmptyString.html#Create">
+</object>
+</ul>
+</ul>
+<li><object type="text/sitemap">
+<param name="Name" value="MinimumIntegerAttribute">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Methods">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html#@Methods">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html#Create">
+</object>
+</ul>
+</ul>
+<li><object type="text/sitemap">
+<param name="Name" value="MaximumIntegerAttribute">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Methods">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html#@Methods">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html#Create">
+</object>
+</ul>
+</ul>
+<li><object type="text/sitemap">
 <param name="Name" value="TPerson">
 <param name="Local" value="ok_attributes.TPerson.html">
 </object>
@@ -145,6 +193,54 @@
 <param name="Local" value="ok_attributes.IUIContainer.html">
 </object>
 <ul>
+</ul>
+<li><object type="text/sitemap">
+<param name="Name" value="MaximumIntegerAttribute">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Methods">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html#@Methods">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html#Create">
+</object>
+</ul>
+</ul>
+<li><object type="text/sitemap">
+<param name="Name" value="MinimumIntegerAttribute">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Methods">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html#@Methods">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html#Create">
+</object>
+</ul>
+</ul>
+<li><object type="text/sitemap">
+<param name="Name" value="NonEmptyString">
+<param name="Local" value="ok_attributes.NonEmptyString.html">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Methods">
+<param name="Local" value="ok_attributes.NonEmptyString.html#@Methods">
+</object>
+<ul>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.NonEmptyString.html#Create">
+</object>
+</ul>
 </ul>
 <li><object type="text/sitemap">
 <param name="Name" value="TMyClass1">

--- a/tests/testcases_output/htmlhelp/ok_attributes/docs.hhk
+++ b/tests/testcases_output/htmlhelp/ok_attributes/docs.hhk
@@ -20,6 +20,30 @@
 <param name="Local" value="ok_attributes.IUIContainer.html">
 </object>
 <li><object type="text/sitemap">
+<param name="Name" value="MaximumIntegerAttribute">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html">
+</object>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.MaximumIntegerAttribute.html#Create-Integer-String-">
+</object>
+<li><object type="text/sitemap">
+<param name="Name" value="MinimumIntegerAttribute">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html">
+</object>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.MinimumIntegerAttribute.html#Create-Integer-String-">
+</object>
+<li><object type="text/sitemap">
+<param name="Name" value="NonEmptyString">
+<param name="Local" value="ok_attributes.NonEmptyString.html">
+</object>
+<li><object type="text/sitemap">
+<param name="Name" value="Create">
+<param name="Local" value="ok_attributes.NonEmptyString.html#Create-String-">
+</object>
+<li><object type="text/sitemap">
 <param name="Name" value="TMyClass1">
 <param name="Local" value="ok_attributes.TMyClass1.html">
 </object>

--- a/tests/testcases_output/htmlhelp/ok_attributes/docs.hhp
+++ b/tests/testcases_output/htmlhelp/ok_attributes/docs.hhp
@@ -25,6 +25,9 @@ AllConstants.html
 AllFunctions.html
 AllIdentifiers.html
 ok_attributes.html
+ok_attributes.NonEmptyString.html
+ok_attributes.MinimumIntegerAttribute.html
+ok_attributes.MaximumIntegerAttribute.html
 ok_attributes.TPerson.html
 ok_attributes.IUIContainer.html
 ok_attributes.TMyClass1.html

--- a/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.MaximumIntegerAttribute.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.MaximumIntegerAttribute.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ok_attributes: Class MaximumIntegerAttribute</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<link rel="StyleSheet" type="text/css" href="pasdoc.css">
+</head>
+<body>
+<span id="MaximumIntegerAttribute"></span><h1 class="cio">Class MaximumIntegerAttribute</h1>
+<div class="sections">
+<div class="one_section"><a class="section" href="#PasDoc-Description">Description</a></div><div class="one_section"><a class="section" href="#PasDoc-Hierarchy">Hierarchy</a></div><div class="one_section">Fields</div><div class="one_section"><a class="section" href="#PasDoc-Methods">Methods</a></div><div class="one_section">Properties</div></div>
+<span id="PasDoc-Description"></span><h2 class="unit">Unit</h2>
+<p class="unitlink">
+<a href="ok_attributes.html">ok_attributes</a></p>
+<h2 class="declaration">Declaration</h2>
+<p class="declaration">
+<code>type MaximumIntegerAttribute = class(TCustomAttribute)</code></p>
+<h2 class="description">Description</h2>
+<p>
+Attribute class, with Attribute suffix, PasDoc should link to it too</p>
+<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<ul class="hierarchy"><li class="ancestor">TCustomAttribute</li>
+<li class="thisitem">MaximumIntegerAttribute</li></ul><h2 class="overview">Overview</h2>
+<span id="PasDoc-Methods"></span><h3 class="summary">Methods</h3>
+<table class="summary wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><code>constructor <strong><a href="ok_attributes.MaximumIntegerAttribute.html#Create-Integer-String-">Create</a></strong>(const MaxInt: Integer; const AMessage: String);</code></td>
+</tr>
+</table>
+<h2 class="description">Description</h2>
+<h3 class="detail">Methods</h3>
+<table class="detail wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><span id="Create-Integer-String-"></span><code>constructor <strong>Create</strong>(const MaxInt: Integer; const AMessage: String);</code></td>
+</tr>
+<tr><td colspan="2">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+</body></html>

--- a/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.MinimumIntegerAttribute.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.MinimumIntegerAttribute.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ok_attributes: Class MinimumIntegerAttribute</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<link rel="StyleSheet" type="text/css" href="pasdoc.css">
+</head>
+<body>
+<span id="MinimumIntegerAttribute"></span><h1 class="cio">Class MinimumIntegerAttribute</h1>
+<div class="sections">
+<div class="one_section"><a class="section" href="#PasDoc-Description">Description</a></div><div class="one_section"><a class="section" href="#PasDoc-Hierarchy">Hierarchy</a></div><div class="one_section">Fields</div><div class="one_section"><a class="section" href="#PasDoc-Methods">Methods</a></div><div class="one_section">Properties</div></div>
+<span id="PasDoc-Description"></span><h2 class="unit">Unit</h2>
+<p class="unitlink">
+<a href="ok_attributes.html">ok_attributes</a></p>
+<h2 class="declaration">Declaration</h2>
+<p class="declaration">
+<code>type MinimumIntegerAttribute = class(TCustomAttribute)</code></p>
+<h2 class="description">Description</h2>
+<p>
+Attribute class, with Attribute suffix, PasDoc should link to it too</p>
+<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<ul class="hierarchy"><li class="ancestor">TCustomAttribute</li>
+<li class="thisitem">MinimumIntegerAttribute</li></ul><h2 class="overview">Overview</h2>
+<span id="PasDoc-Methods"></span><h3 class="summary">Methods</h3>
+<table class="summary wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><code>constructor <strong><a href="ok_attributes.MinimumIntegerAttribute.html#Create-Integer-String-">Create</a></strong>(const MinInt: Integer; const AMessage: String);</code></td>
+</tr>
+</table>
+<h2 class="description">Description</h2>
+<h3 class="detail">Methods</h3>
+<table class="detail wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><span id="Create-Integer-String-"></span><code>constructor <strong>Create</strong>(const MinInt: Integer; const AMessage: String);</code></td>
+</tr>
+<tr><td colspan="2">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+</body></html>

--- a/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.NonEmptyString.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.NonEmptyString.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ok_attributes: Class NonEmptyString</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<link rel="StyleSheet" type="text/css" href="pasdoc.css">
+</head>
+<body>
+<span id="NonEmptyString"></span><h1 class="cio">Class NonEmptyString</h1>
+<div class="sections">
+<div class="one_section"><a class="section" href="#PasDoc-Description">Description</a></div><div class="one_section"><a class="section" href="#PasDoc-Hierarchy">Hierarchy</a></div><div class="one_section">Fields</div><div class="one_section"><a class="section" href="#PasDoc-Methods">Methods</a></div><div class="one_section">Properties</div></div>
+<span id="PasDoc-Description"></span><h2 class="unit">Unit</h2>
+<p class="unitlink">
+<a href="ok_attributes.html">ok_attributes</a></p>
+<h2 class="declaration">Declaration</h2>
+<p class="declaration">
+<code>type NonEmptyString = class(TCustomAttribute)</code></p>
+<h2 class="description">Description</h2>
+<p>
+Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a> Attribute class, without Attribute suffix, PasDoc should link to it</p>
+<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<ul class="hierarchy"><li class="ancestor">TCustomAttribute</li>
+<li class="thisitem">NonEmptyString</li></ul><h2 class="overview">Overview</h2>
+<span id="PasDoc-Methods"></span><h3 class="summary">Methods</h3>
+<table class="summary wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><code>constructor <strong><a href="ok_attributes.NonEmptyString.html#Create-String-">Create</a></strong>(const AMessage: String);</code></td>
+</tr>
+</table>
+<h2 class="description">Description</h2>
+<h3 class="detail">Methods</h3>
+<table class="detail wide_list">
+<tr class="list">
+<td class="visibility"><a href="legend.html"><img  src="public.gif" alt="Public" title="Public"></a></td>
+<td class="itemcode"><span id="Create-String-"></span><code>constructor <strong>Create</strong>(const AMessage: String);</code></td>
+</tr>
+<tr><td colspan="2">
+<p class="nodescription">This item has no description.</p></td></tr>
+</table>
+</body></html>

--- a/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.TPerson.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.TPerson.html
@@ -17,9 +17,7 @@
 <p class="declaration">
 <code>type TPerson = class(TObject)</code></p>
 <h2 class="description">Description</h2>
-<p>
-Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">http://www.malcolmgroves.com/blog/?p=530</a></p>
-<span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
+<p class="nodescription">This item has no description.</p><span id="PasDoc-Hierarchy"></span><h2 class="hierarchy">Hierarchy</h2>
 <ul class="hierarchy"><li class="ancestor">TObject</li>
 <li class="thisitem">TPerson</li></ul><h2 class="overview">Overview</h2>
 <span id="PasDoc-Properties"></span><h3 class="summary">Properties</h3>
@@ -43,7 +41,7 @@ Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">h
 <tr><td colspan="2">
 <p class="nodescription">This item has no description.</p><h6 class="description_section">Attributes</h6>
 <dl class="attributes">
-  <dt><code>NonEmptyString</code>('Must provide a Name')</dt>
+  <dt><a class="normal" href="ok_attributes.NonEmptyString.html">NonEmptyString</a>('Must provide a Name')</dt>
   <dd></dd>
 </dl>
 </td></tr>
@@ -56,9 +54,9 @@ Delphi attributes test from <a href="http://www.malcolmgroves.com/blog/?p=530">h
 <tr><td colspan="2">
 <p class="nodescription">This item has no description.</p><h6 class="description_section">Attributes</h6>
 <dl class="attributes">
-  <dt><code>MinimumInteger</code>(18, 'Must be at least 18 years old')</dt>
+  <dt><a class="normal" href="ok_attributes.MinimumIntegerAttribute.html">MinimumInteger</a>(18, 'Must be at least 18 years old')</dt>
   <dd></dd>
-  <dt><code>MaximumInteger</code>(65, 'Must be no older than 65 years')</dt>
+  <dt><a class="normal" href="ok_attributes.MaximumIntegerAttribute.html">MaximumInteger</a>(65, 'Must be no older than 65 years')</dt>
   <dd></dd>
 </dl>
 </td></tr>

--- a/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.html
+++ b/tests/testcases_output/htmlhelp/ok_attributes/ok_attributes.html
@@ -19,22 +19,34 @@
 <th class="itemdesc">Description</th>
 </tr>
 <tr class="list">
+<td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.NonEmptyString.html"><code>NonEmptyString</code></a></td>
+<td class="itemdesc">&nbsp;</td>
+</tr>
+<tr class="list2">
+<td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.MinimumIntegerAttribute.html"><code>MinimumIntegerAttribute</code></a></td>
+<td class="itemdesc">&nbsp;</td>
+</tr>
+<tr class="list">
+<td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.MaximumIntegerAttribute.html"><code>MaximumIntegerAttribute</code></a></td>
+<td class="itemdesc">&nbsp;</td>
+</tr>
+<tr class="list2">
 <td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.TPerson.html"><code>TPerson</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname">Interface&nbsp;<a class="bold" href="ok_attributes.IUIContainer.html"><code>IUIContainer</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.TMyClass1.html"><code>TMyClass1</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list2">
+<tr class="list">
 <td class="itemname">Class&nbsp;<a class="bold" href="ok_attributes.TMyClass2.html"><code>TMyClass2</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>
-<tr class="list">
+<tr class="list2">
 <td class="itemname">Interface&nbsp;<a class="bold" href="ok_attributes.IEnumerator.generic.html"><code>IEnumerator</code></a></td>
 <td class="itemdesc">&nbsp;</td>
 </tr>

--- a/tests/testcases_output/latex/ok_attributes/docs.tex
+++ b/tests/testcases_output/latex/ok_attributes/docs.tex
@@ -85,6 +85,9 @@
 \index{ok{\_}attributes}
 \section{Overview}
 \begin{description}
+\item[\texttt{\begin{ttfamily}NonEmptyString\end{ttfamily} Class}]
+\item[\texttt{\begin{ttfamily}MinimumIntegerAttribute\end{ttfamily} Class}]
+\item[\texttt{\begin{ttfamily}MaximumIntegerAttribute\end{ttfamily} Class}]
 \item[\texttt{\begin{ttfamily}TPerson\end{ttfamily} Class}]
 \item[\texttt{\begin{ttfamily}IUIContainer\end{ttfamily} Interface}]
 \item[\texttt{\begin{ttfamily}TMyClass1\end{ttfamily} Class}]
@@ -92,6 +95,117 @@
 \item[\texttt{\begin{ttfamily}IEnumerator\end{ttfamily} Interface}]
 \end{description}
 \section{Classes, Interfaces, Objects and Records}
+\ifpdf
+\subsection*{\large{\textbf{NonEmptyString Class}}\normalsize\hspace{1ex}\hrulefill}
+\else
+\subsection*{NonEmptyString Class}
+\fi
+\label{ok_attributes.NonEmptyString}
+\index{NonEmptyString}
+\subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
+NonEmptyString {$>$} TCustomAttribute
+\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
+Delphi attributes test from \href{http://www.malcolmgroves.com/blog/?p=530}{http://www.malcolmgroves.com/blog/?p=530} Attribute class, without Attribute suffix, PasDoc should link to it\subsubsection*{\large{\textbf{Methods}}\normalsize\hspace{1ex}\hfill}
+\paragraph*{Create}\hspace*{\fill}
+
+\label{ok_attributes.NonEmptyString-Create}
+\index{Create}
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\item[\textbf{Declaration}\hfill]
+\ifpdf
+\begin{flushleft}
+\fi
+\begin{ttfamily}
+public constructor Create(const AMessage: String);\end{ttfamily}
+
+\ifpdf
+\end{flushleft}
+\fi
+
+\end{list}
+\ifpdf
+\subsection*{\large{\textbf{MinimumIntegerAttribute Class}}\normalsize\hspace{1ex}\hrulefill}
+\else
+\subsection*{MinimumIntegerAttribute Class}
+\fi
+\label{ok_attributes.MinimumIntegerAttribute}
+\index{MinimumIntegerAttribute}
+\subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
+MinimumIntegerAttribute {$>$} TCustomAttribute
+\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
+Attribute class, with Attribute suffix, PasDoc should link to it too\subsubsection*{\large{\textbf{Methods}}\normalsize\hspace{1ex}\hfill}
+\paragraph*{Create}\hspace*{\fill}
+
+\label{ok_attributes.MinimumIntegerAttribute-Create}
+\index{Create}
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\item[\textbf{Declaration}\hfill]
+\ifpdf
+\begin{flushleft}
+\fi
+\begin{ttfamily}
+public constructor Create(const MinInt: Integer; const AMessage: String);\end{ttfamily}
+
+\ifpdf
+\end{flushleft}
+\fi
+
+\end{list}
+\ifpdf
+\subsection*{\large{\textbf{MaximumIntegerAttribute Class}}\normalsize\hspace{1ex}\hrulefill}
+\else
+\subsection*{MaximumIntegerAttribute Class}
+\fi
+\label{ok_attributes.MaximumIntegerAttribute}
+\index{MaximumIntegerAttribute}
+\subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
+MaximumIntegerAttribute {$>$} TCustomAttribute
+\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
+Attribute class, with Attribute suffix, PasDoc should link to it too\subsubsection*{\large{\textbf{Methods}}\normalsize\hspace{1ex}\hfill}
+\paragraph*{Create}\hspace*{\fill}
+
+\label{ok_attributes.MaximumIntegerAttribute-Create}
+\index{Create}
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\item[\textbf{Declaration}\hfill]
+\ifpdf
+\begin{flushleft}
+\fi
+\begin{ttfamily}
+public constructor Create(const MaxInt: Integer; const AMessage: String);\end{ttfamily}
+
+\ifpdf
+\end{flushleft}
+\fi
+
+\end{list}
 \ifpdf
 \subsection*{\large{\textbf{TPerson Class}}\normalsize\hspace{1ex}\hrulefill}
 \else
@@ -101,8 +215,8 @@
 \index{TPerson}
 \subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
 TPerson {$>$} TObject
-\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
-Delphi attributes test from \href{http://www.malcolmgroves.com/blog/?p=530}{http://www.malcolmgroves.com/blog/?p=530}\subsubsection*{\large{\textbf{Properties}}\normalsize\hspace{1ex}\hfill}
+%%%%Description
+\subsubsection*{\large{\textbf{Properties}}\normalsize\hspace{1ex}\hfill}
 \begin{list}{}{
 \settowidth{\tmplength}{\textbf{Name}}
 \setlength{\itemindent}{0cm}

--- a/tests/testcases_output/latex2rtf/ok_attributes/docs.tex
+++ b/tests/testcases_output/latex2rtf/ok_attributes/docs.tex
@@ -61,6 +61,9 @@
 \chapter{Unit ok{\_}attributes}
 \section{Overview}
 \begin{description}
+\item[\texttt{\begin{ttfamily}NonEmptyString\end{ttfamily} Class}]
+\item[\texttt{\begin{ttfamily}MinimumIntegerAttribute\end{ttfamily} Class}]
+\item[\texttt{\begin{ttfamily}MaximumIntegerAttribute\end{ttfamily} Class}]
 \item[\texttt{\begin{ttfamily}TPerson\end{ttfamily} Class}]
 \item[\texttt{\begin{ttfamily}IUIContainer\end{ttfamily} Interface}]
 \item[\texttt{\begin{ttfamily}TMyClass1\end{ttfamily} Class}]
@@ -68,11 +71,86 @@
 \item[\texttt{\begin{ttfamily}IEnumerator\end{ttfamily} Interface}]
 \end{description}
 \section{Classes, Interfaces, Objects and Records}
+\subsection*{NonEmptyString Class}
+\subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
+NonEmptyString {$>$} TCustomAttribute
+\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
+Delphi attributes test from http://www.malcolmgroves.com/blog/?p=530 Attribute class, without Attribute suffix, PasDoc should link to it\subsubsection*{\large{\textbf{Methods}}\normalsize\hspace{1ex}\hfill}
+\paragraph*{Create}\hspace*{\fill}
+
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\begin{flushleft}
+\item[\textbf{Declaration}\hfill]
+\begin{ttfamily}
+public constructor Create(const AMessage: String);\end{ttfamily}
+
+
+\end{flushleft}
+\end{list}
+\subsection*{MinimumIntegerAttribute Class}
+\subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
+MinimumIntegerAttribute {$>$} TCustomAttribute
+\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
+Attribute class, with Attribute suffix, PasDoc should link to it too\subsubsection*{\large{\textbf{Methods}}\normalsize\hspace{1ex}\hfill}
+\paragraph*{Create}\hspace*{\fill}
+
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\begin{flushleft}
+\item[\textbf{Declaration}\hfill]
+\begin{ttfamily}
+public constructor Create(const MinInt: Integer; const AMessage: String);\end{ttfamily}
+
+
+\end{flushleft}
+\end{list}
+\subsection*{MaximumIntegerAttribute Class}
+\subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
+MaximumIntegerAttribute {$>$} TCustomAttribute
+\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
+Attribute class, with Attribute suffix, PasDoc should link to it too\subsubsection*{\large{\textbf{Methods}}\normalsize\hspace{1ex}\hfill}
+\paragraph*{Create}\hspace*{\fill}
+
+\begin{list}{}{
+\settowidth{\tmplength}{\textbf{Description}}
+\setlength{\itemindent}{0cm}
+\setlength{\listparindent}{0cm}
+\setlength{\leftmargin}{\evensidemargin}
+\addtolength{\leftmargin}{\tmplength}
+\settowidth{\labelsep}{X}
+\addtolength{\leftmargin}{\labelsep}
+\setlength{\labelwidth}{\tmplength}
+}
+\begin{flushleft}
+\item[\textbf{Declaration}\hfill]
+\begin{ttfamily}
+public constructor Create(const MaxInt: Integer; const AMessage: String);\end{ttfamily}
+
+
+\end{flushleft}
+\end{list}
 \subsection*{TPerson Class}
 \subsubsection*{\large{\textbf{Hierarchy}}\normalsize\hspace{1ex}\hfill}
 TPerson {$>$} TObject
-\subsubsection*{\large{\textbf{Description}}\normalsize\hspace{1ex}\hfill}
-Delphi attributes test from http://www.malcolmgroves.com/blog/?p=530\subsubsection*{\large{\textbf{Properties}}\normalsize\hspace{1ex}\hfill}
+%%%%Description
+\subsubsection*{\large{\textbf{Properties}}\normalsize\hspace{1ex}\hfill}
 \paragraph*{Name}\hspace*{\fill}
 
 \begin{list}{}{

--- a/tests/testcases_output/php/ok_attributes/docs.php
+++ b/tests/testcases_output/php/ok_attributes/docs.php
@@ -2,6 +2,12 @@
 global $pasdoc;
 $pasdoc = array(
   'ok_attributes' => array('html_filename' => 'ok_attributes.html', 'type' => 'unit'),
+  'NonEmptyString' => array('html_filename' => 'ok_attributes.NonEmptyString.html', 'type' => 'class'),
+  'NonEmptyString.Create' => array('html_filename' => 'ok_attributes.NonEmptyString.html#Create-String-', 'type' => 'constructor'),
+  'MinimumIntegerAttribute' => array('html_filename' => 'ok_attributes.MinimumIntegerAttribute.html', 'type' => 'class'),
+  'MinimumIntegerAttribute.Create' => array('html_filename' => 'ok_attributes.MinimumIntegerAttribute.html#Create-Integer-String-', 'type' => 'constructor'),
+  'MaximumIntegerAttribute' => array('html_filename' => 'ok_attributes.MaximumIntegerAttribute.html', 'type' => 'class'),
+  'MaximumIntegerAttribute.Create' => array('html_filename' => 'ok_attributes.MaximumIntegerAttribute.html#Create-Integer-String-', 'type' => 'constructor'),
   'TPerson' => array('html_filename' => 'ok_attributes.TPerson.html', 'type' => 'class'),
   'TPerson.Name' => array('html_filename' => 'ok_attributes.TPerson.html#Name', 'type' => 'property'),
   'TPerson.Age' => array('html_filename' => 'ok_attributes.TPerson.html#Age', 'type' => 'property'),

--- a/tests/testcases_output/simplexml/ok_attributes/ok_attributes.xml
+++ b/tests/testcases_output/simplexml/ok_attributes/ok_attributes.xml
@@ -1,6 +1,23 @@
 <unit name="ok_attributes.pas">
+  <structure name="NonEmptyString" name_with_generic="NonEmptyString" type="class" visibility="published">
+    <description><detailed>Delphi attributes test from http://www.malcolmgroves.com/blog/?p=530 Attribute class, without Attribute suffix, PasDoc should link to it</detailed></description>
+    <ancestor name="TCustomAttribute" declaration="TCustomAttribute" />
+    <routine name="Create" type="constructor" declaration="constructor Create(const AMessage: String);" visibility="public">
+    </routine>
+  </structure>
+  <structure name="MinimumIntegerAttribute" name_with_generic="MinimumIntegerAttribute" type="class" visibility="published">
+    <description><detailed>Attribute class, with Attribute suffix, PasDoc should link to it too</detailed></description>
+    <ancestor name="TCustomAttribute" declaration="TCustomAttribute" />
+    <routine name="Create" type="constructor" declaration="constructor Create(const MinInt: Integer; const AMessage: String);" visibility="public">
+    </routine>
+  </structure>
+  <structure name="MaximumIntegerAttribute" name_with_generic="MaximumIntegerAttribute" type="class" visibility="published">
+    <description><detailed>Attribute class, with Attribute suffix, PasDoc should link to it too</detailed></description>
+    <ancestor name="TCustomAttribute" declaration="TCustomAttribute" />
+    <routine name="Create" type="constructor" declaration="constructor Create(const MaxInt: Integer; const AMessage: String);" visibility="public">
+    </routine>
+  </structure>
   <structure name="TPerson" name_with_generic="TPerson" type="class" visibility="published">
-    <description><detailed>Delphi attributes test from http://www.malcolmgroves.com/blog/?p=530</detailed></description>
     <ancestor name="TObject" declaration="TObject" />
     <property name="Name" indexdecl="" type="String" reader="FName" writer="FName" default_in_class="False" default_value="" nodefault="False"   stored="" visibility="public">
     </property>


### PR DESCRIPTION
PasDoc currently fails to resolve attributes that omit the "Attribute" suffix. This PR modifies the HTML gen `WriteAttributes` method to try searching for the attribute's name with the suffix if the initial search fails.